### PR TITLE
feat: local daemon (chocodropd) + browser SDK + UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ChocoDrop
-ちょこっとDrop。  
+ちょこっとDrop。
 世界が咲く。
 
 Drop a little, bloom a lot.
@@ -8,7 +8,36 @@ Drop a little, bloom a lot.
 - 🎮 Demo: https://nyukicorn.github.io/chocodrop/examples/basic/
 - 📚 Docs: ./docs/GETTING_STARTED.md
 
-## ⚡ クイックスタート
+## 🆕 新アーキテクチャ（v2.0）
+
+ChocoDrop は常駐 daemon + ブラウザ SDK の新アーキテクチャに移行しました！
+
+### 🚀 超簡単クイックスタート
+
+**Step 1:** daemon を起動（1度だけ）
+```bash
+npx chocodropd
+```
+
+**Step 2:** どの Three.js ページでも1行で動く
+```html
+<script src="http://127.0.0.1:43110/sdk.js"></script>
+<script type="module">
+  await window.chocodrop.ready();
+  await window.chocodrop.attach(scene, { camera, renderer });
+</script>
+```
+
+**または：ブックマークレット**（既存ページに即追加）
+```javascript
+javascript:(()=>{const u='http://127.0.0.1:43110/sdk.js';if(document.getElementById('__chocodrop_sdk'))return;const s=document.createElement('script');s.id='__chocodrop_sdk';s.src=u;s.onload=async()=>{try{await window.chocodrop.ready();const scene=window.scene||document.querySelector('canvas')?.__scene__;if(scene){await window.chocodrop.attach(scene,{});}}catch(e){console.error('ChocoDrop:',e);}};document.head.appendChild(s);})();
+```
+
+[📖 ブックマークレットの使い方](examples/bookmarklet.html)
+
+---
+
+## ⚡ 旧API（v1.x - 非推奨）
 
 ```bash
 # npm/yarn
@@ -20,6 +49,8 @@ createChocoDrop(scene, { camera, renderer, enableMouseInteraction: true });
 import { createChocoDrop } from './src/index.js';
 createChocoDrop(scene, { camera, renderer, enableMouseInteraction: true });
 ```
+
+**⚠️ 注意:** 旧APIは v3.0 で削除予定です。新アーキテクチャへの移行を推奨します。
 
 **🎮 使い方:** `@`キー → 自然言語入力 → 完了
 **🖱️ 重要:** `enableMouseInteraction: true` でオブジェクト選択・移動・編集が可能に！

--- a/examples/bookmarklet.html
+++ b/examples/bookmarklet.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ChocoDrop Bookmarklet</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            max-width: 800px;
+            margin: 40px auto;
+            padding: 20px;
+            background: #0a0a0a;
+            color: #fff;
+        }
+        h1 {
+            color: #ff6ad5;
+        }
+        .bookmarklet {
+            background: rgba(255, 255, 255, 0.1);
+            border: 2px dashed #ff6ad5;
+            padding: 20px;
+            border-radius: 12px;
+            margin: 20px 0;
+        }
+        .bookmarklet-link {
+            display: inline-block;
+            background: #ff6ad5;
+            color: #000;
+            padding: 12px 24px;
+            border-radius: 8px;
+            text-decoration: none;
+            font-weight: 600;
+            margin: 10px 0;
+        }
+        .bookmarklet-link:hover {
+            background: #ff4dc4;
+        }
+        code {
+            background: rgba(255, 255, 255, 0.1);
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-family: monospace;
+        }
+        pre {
+            background: rgba(255, 255, 255, 0.05);
+            padding: 15px;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+        .step {
+            background: rgba(255, 255, 255, 0.05);
+            padding: 15px;
+            margin: 10px 0;
+            border-left: 4px solid #ff6ad5;
+            border-radius: 4px;
+        }
+    </style>
+</head>
+<body>
+    <h1>🍫 ChocoDrop Bookmarklet</h1>
+
+    <p>ChocoDrop をどんな Three.js ページにも1クリックで追加できます。</p>
+
+    <div class="bookmarklet">
+        <h2>📌 使い方</h2>
+
+        <div class="step">
+            <strong>Step 1:</strong> daemon を起動
+            <pre>npx chocodropd</pre>
+        </div>
+
+        <div class="step">
+            <strong>Step 2:</strong> このリンクをブックマークバーにドラッグ＆ドロップ
+            <div style="margin-top: 10px;">
+                <a href="javascript:(()=>{const u='http://127.0.0.1:43110/sdk.js';if(document.getElementById('__chocodrop_sdk'))return;const s=document.createElement('script');s.id='__chocodrop_sdk';s.src=u;s.onload=async()=>{try{await window.chocodrop.ready();const scene=window.scene||document.querySelector('canvas')?.__scene__;if(scene){await window.chocodrop.attach(scene,{});}}catch(e){console.error('ChocoDrop:',e);}};document.head.appendChild(s);})();" class="bookmarklet-link">
+                    🍫 ChocoDrop
+                </a>
+            </div>
+        </div>
+
+        <div class="step">
+            <strong>Step 3:</strong> Three.js ページでブックマークをクリック
+        </div>
+    </div>
+
+    <h2>📝 コード</h2>
+    <p>手動で使う場合は、このコードをコンソールに貼り付けてください：</p>
+    <pre><code>(() => {
+  const u = 'http://127.0.0.1:43110/sdk.js';
+  if (document.getElementById('__chocodrop_sdk')) return;
+
+  const s = document.createElement('script');
+  s.id = '__chocodrop_sdk';
+  s.src = u;
+
+  s.onload = async () => {
+    try {
+      await window.chocodrop.ready();
+
+      // Try to find scene object
+      const scene = window.scene ||
+                   document.querySelector('canvas')?.__scene__;
+
+      if (scene) {
+        await window.chocodrop.attach(scene, {});
+      } else {
+        console.warn('No Three.js scene found');
+      }
+    } catch (e) {
+      console.error('ChocoDrop:', e);
+    }
+  };
+
+  document.head.appendChild(s);
+})();</code></pre>
+
+    <h2>🔧 注意事項</h2>
+    <ul>
+        <li>daemon が起動していることを確認してください</li>
+        <li>CORS のため、ローカルサーバーで配信されているページで使用してください</li>
+        <li><code>file://</code> プロトコルでは動作しません</li>
+    </ul>
+
+    <h2>💡 対応ページの例</h2>
+    <ul>
+        <li><a href="../index.html" target="_blank">ChocoDrop デモページ</a></li>
+        <li><a href="./basic/index.html" target="_blank">Basic Example</a></li>
+        <li><a href="./test-new-sdk.html" target="_blank">New SDK Test</a></li>
+    </ul>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "chocodrop",
       "version": "1.0.0",
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "cors": "^2.8.5",
@@ -26,6 +29,14 @@
       "peerDependencies": {
         "three": ">=0.170.0 <=0.180.0"
       }
+    },
+    "node_modules/@chocodrop/daemon": {
+      "resolved": "packages/daemon",
+      "link": true
+    },
+    "node_modules/@chocodrop/sdk": {
+      "resolved": "packages/sdk",
+      "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
@@ -951,6 +962,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chocodrop": {
+      "resolved": "packages/meta",
+      "link": true
     },
     "node_modules/commander": {
       "version": "2.20.3",
@@ -2211,6 +2226,48 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "packages/daemon": {
+      "name": "@chocodrop/daemon",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.5",
+        "cors": "^2.8.5",
+        "express": "^4.19.0"
+      },
+      "bin": {
+        "chocodropd": "bin/chocodropd.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "packages/meta": {
+      "name": "chocodrop",
+      "version": "2.0.0",
+      "deprecated": "Please use @chocodrop/sdk directly. This package will be removed in v3.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@chocodrop/sdk": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "three": ">=0.170.0 <=0.180.0"
+      }
+    },
+    "packages/sdk": {
+      "name": "@chocodrop/sdk",
+      "version": "1.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "three": ">=0.170.0 <=0.180.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/nyukicorn/chocodrop/issues"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "main": "src/index.js",
   "type": "module",
   "exports": {

--- a/packages/daemon/bin/chocodropd.js
+++ b/packages/daemon/bin/chocodropd.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+/**
+ * ChocoDrop Daemon - Local server for SDK distribution and MCP bridging
+ *
+ * This daemon runs on 127.0.0.1:43110 (local only) and provides:
+ * - SDK distribution (/sdk.js)
+ * - Health check (/v1/health)
+ * - MCP bridging (/v1/generate)
+ * - Settings UI (/settings)
+ */
+
+import { startDaemon } from '../src/index.js';
+
+const PORT = process.env.CHOCODROP_PORT || 43110;
+const HOST = '127.0.0.1'; // Local only - security by default
+
+console.log('🍫 ChocoDrop Daemon starting...');
+console.log(`   Host: ${HOST}`);
+console.log(`   Port: ${PORT}`);
+console.log(`   Mode: ${process.env.NODE_ENV || 'development'}`);
+
+startDaemon({ host: HOST, port: PORT })
+  .then(() => {
+    console.log('✅ ChocoDrop Daemon is ready!');
+    console.log(`   Health: http://${HOST}:${PORT}/v1/health`);
+    console.log(`   SDK: http://${HOST}:${PORT}/sdk.js`);
+    console.log('');
+    console.log('Press Ctrl+C to stop');
+  })
+  .catch((err) => {
+    console.error('❌ Failed to start daemon:', err);
+    process.exit(1);
+  });
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n🛑 Shutting down ChocoDrop Daemon...');
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  console.log('\n🛑 Shutting down ChocoDrop Daemon...');
+  process.exit(0);
+});

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@chocodrop/daemon",
+  "version": "1.0.0",
+  "description": "ChocoDrop daemon - local server for SDK distribution and MCP bridging",
+  "type": "module",
+  "bin": {
+    "chocodropd": "./bin/chocodropd.js"
+  },
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "keywords": [
+    "chocodrop",
+    "daemon",
+    "mcp",
+    "local-server"
+  ],
+  "author": {
+    "name": "ChocoDrop Project",
+    "email": "chocodrop.dev@gmail.com"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.5",
+    "cors": "^2.8.5",
+    "express": "^4.19.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/packages/daemon/src/config/config.js
+++ b/packages/daemon/src/config/config.js
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+class Config {
+  constructor() {
+    this.config = this.loadConfig();
+  }
+
+  loadConfig() {
+    const configPaths = [
+      path.join(process.cwd(), 'config.json'),
+      path.join(process.cwd(), 'config.local.json'),
+      path.join(__dirname, '../../config.json'),
+      path.join(__dirname, '../../config.local.json')
+    ];
+
+    for (const configPath of configPaths) {
+      if (fs.existsSync(configPath)) {
+        console.log(`📁 Loading config from: ${configPath}`);
+        const configData = fs.readFileSync(configPath, 'utf-8');
+        return JSON.parse(configData);
+      }
+    }
+
+    // デフォルト設定
+    console.log('⚠️ No config file found, using defaults');
+    return {
+      mcp: {
+        provider: 'kamui-code',
+        configPath: process.env.MCP_CONFIG_PATH || '/path/to/your/mcp-config.json'
+      },
+      models: {
+        image: {
+          default: process.env.DEFAULT_IMAGE_MODEL || 't2i-default-model',
+          options: []
+        },
+        video: {
+          default: process.env.DEFAULT_VIDEO_MODEL || 't2v-default-model',
+          options: []
+        }
+      },
+      server: {
+        port: parseInt(process.env.PORT || '3011'),
+        host: process.env.HOST || 'localhost',
+        outputDir: process.env.OUTPUT_DIR || './public/generated'
+      },
+      client: {
+        serverUrl: process.env.CLIENT_SERVER_URL || `http://localhost:${parseInt(process.env.PORT || '3011')}`,
+        defaultWidth: parseInt(process.env.DEFAULT_WIDTH || '512'),
+        defaultHeight: parseInt(process.env.DEFAULT_HEIGHT || '512'),
+        defaultDuration: parseInt(process.env.DEFAULT_DURATION || '3')
+      }
+    };
+  }
+
+  get(path) {
+    const keys = path.split('.');
+    let value = this.config;
+
+    for (const key of keys) {
+      if (value && typeof value === 'object' && key in value) {
+        value = value[key];
+      } else {
+        return undefined;
+      }
+    }
+
+    return value;
+  }
+
+  getAll() {
+    return this.config;
+  }
+}
+
+export default new Config();

--- a/packages/daemon/src/config/models.js
+++ b/packages/daemon/src/config/models.js
@@ -1,0 +1,233 @@
+/**
+ * 画像生成モデル設定
+ * モデルの一元管理と簡単な切り替えを可能にする
+ */
+
+// 利用可能なモデル一覧
+export const MODELS = {
+  // 高速・軽量（推奨：プロトタイピング用）
+  QWEN_IMAGE: {
+    id: 't2i-kamui-qwen-image',
+    name: 'Qwen Image',
+    description: '高速生成（1-2秒）、軽量だがやや品質劣る',
+    speed: 'fast',
+    quality: 'medium',
+    timeout: 10000, // 10秒
+    estimatedTime: '1-2秒'
+  },
+  
+  // 高品質（推奨：本格利用）
+  SEEDREAM_V4: {
+    id: 't2i-kamui-seedream-v4',
+    name: 'Seedream V4',
+    description: '高品質・詳細（10-15秒）、写実的で鮮明',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 30000, // 30秒
+    estimatedTime: '10-15秒'
+  },
+  
+  // 最高品質（推奨：最終成果物用）
+  FLUX_SCHNELL: {
+    id: 't2i-kamui-flux-schnell',
+    name: 'Flux Schnell',
+    description: '最高品質（15-20秒）、非常に詳細',
+    speed: 'slow',
+    quality: 'highest',
+    timeout: 40000, // 40秒
+    estimatedTime: '15-20秒'
+  },
+  
+  // 高品質バランス型
+  IMAGEN4_FAST: {
+    id: 't2i-kamui-imagen4-fast',
+    name: 'Imagen4 Fast',
+    description: '高品質・高速バランス型',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 25000, // 25秒
+    estimatedTime: '8-12秒'
+  },
+  
+  IMAGEN4_ULTRA: {
+    id: 't2i-kamui-imagen4-ultra',
+    name: 'Imagen4 Ultra',
+    description: '最高品質Google Imagen4（15-20秒）',
+    speed: 'slow',
+    quality: 'highest',
+    timeout: 40000, // 40秒
+    estimatedTime: '15-20秒'
+  },
+  
+  GEMINI_25_FLASH: {
+    id: 't2i-kamui-gemini-25-flash-image',
+    name: 'Gemini 2.5 Flash',
+    description: 'Google最新モデル（8-12秒）',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 25000, // 25秒
+    estimatedTime: '8-12秒'
+  },
+  
+  // 特殊用途モデル
+  DREAMINA_V31: {
+    id: 't2i-kamui-dreamina-v31',
+    name: 'Dreamina v3.1',
+    description: 'ByteDance最新（10-15秒）、アニメ・イラスト特化',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 30000, // 30秒
+    estimatedTime: '10-15秒'
+  },
+  
+  FLUX_KREA_LORA: {
+    id: 't2i-kamui-flux-krea-lora',
+    name: 'Flux Krea LoRA',
+    description: 'FLUX LoRA特化（12-18秒）、スタイル強化',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 35000, // 35秒
+    estimatedTime: '12-18秒'
+  },
+  
+  IDEOGRAM_CHARACTER: {
+    id: 't2i-kamui-ideogram-character-base',
+    name: 'Ideogram Character',
+    description: 'キャラクター一貫性特化（8-12秒）',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 25000, // 25秒
+    estimatedTime: '8-12秒'
+  },
+  
+  IMAGEN3: {
+    id: 't2i-kamui-imagen3',
+    name: 'Imagen 3',
+    description: 'Google Imagen 3（10-15秒）、高品質',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 30000, // 30秒
+    estimatedTime: '10-15秒'
+  },
+  
+  WAN_V2_2_A14B: {
+    id: 't2i-kamui-wan-v2-2-a14b',
+    name: 'WAN v2.2-a14b',
+    description: 'WAN最新（8-12秒）、リアル志向',
+    speed: 'medium',
+    quality: 'high',
+    timeout: 25000, // 25秒
+    estimatedTime: '8-12秒'
+  },
+  
+  NANO_BANANA: {
+    id: 't2i-kamui-nano-banana',
+    name: 'Nano Banana',
+    description: '軽量高速（3-5秒）、実験的',
+    speed: 'fast',
+    quality: 'medium',
+    timeout: 15000, // 15秒
+    estimatedTime: '3-5秒'
+  },
+  
+  // Text-to-Video Models
+  WAN_V2_2_5B_FAST_VIDEO: {
+    id: 't2v-kamui-wan-v2-2-5b-fast',
+    name: 'WAN v2.2-5b FastVideo',
+    description: '超高速動画生成（15-30秒）、T2V特化',
+    speed: 'fast',
+    quality: 'high',
+    type: 'video',
+    timeout: 60000, // 60秒
+    estimatedTime: '15-30秒'
+  },
+  
+  VEO3_FAST_VIDEO: {
+    id: 't2v-kamui-veo3-fast',
+    name: 'Veo3 Fast',
+    description: 'Google Veo3高速動画生成（20-40秒）、多言語対応',
+    speed: 'fast',
+    quality: 'high',
+    type: 'video',
+    timeout: 80000, // 80秒
+    estimatedTime: '20-40秒'
+  }
+};
+
+// デフォルトモデル設定
+export const DEFAULT_MODEL = MODELS.SEEDREAM_V4; // 高品質・鮮明画像
+
+// 用途別推奨モデル
+export const RECOMMENDED = {
+  // プロトタイピング・テスト用
+  PROTOTYPE: MODELS.QWEN_IMAGE,
+  
+  // 通常利用・デモ用
+  GENERAL: MODELS.SEEDREAM_V4,
+  
+  // 最終成果物・プレゼン用
+  PRODUCTION: MODELS.FLUX_SCHNELL
+};
+
+// キーワードベースの自動選択
+export const AUTO_SELECT = {
+  '高速': MODELS.QWEN_IMAGE,
+  '高品質': MODELS.FLUX_SCHNELL,
+  '詳細': MODELS.FLUX_SCHNELL,
+  'プロトタイプ': MODELS.QWEN_IMAGE,
+  'テスト': MODELS.QWEN_IMAGE
+};
+
+/**
+ * モデルIDからモデル情報を取得
+ */
+export function getModelById(modelId) {
+  return Object.values(MODELS).find(model => model.id === modelId) || DEFAULT_MODEL;
+}
+
+/**
+ * 利用可能なモデルID一覧を取得
+ */
+export function getAvailableModelIds() {
+  return Object.values(MODELS).map(model => model.id);
+}
+
+/**
+ * コマンドから適切なモデルを自動選択
+ */
+export function selectModelFromCommand(command) {
+  const lowerCommand = command.toLowerCase();
+
+  for (const [keyword, model] of Object.entries(AUTO_SELECT)) {
+    if (lowerCommand.includes(keyword)) {
+      return model;
+    }
+  }
+
+  return DEFAULT_MODEL;
+}
+
+// Legacy exports for compatibility with distribution version
+export const models = Object.values(MODELS).map(model => ({
+  id: model.id,
+  name: model.name,
+  type: model.type || (model.id.includes('t2v') ? 't2v' : 't2i'),
+  provider: 'kamui-code'
+}));
+
+export const defaultModels = {
+  t2i: DEFAULT_MODEL.id,
+  t2v: MODELS.WAN_V2_2_5B_FAST_VIDEO.id
+};
+
+/**
+ * 現在の環境設定
+ */
+export const CONFIG = {
+  // 現在のデフォルトモデル
+  currentDefault: DEFAULT_MODEL,
+  
+  // 環境別設定
+  development: MODELS.QWEN_IMAGE,    // 開発時は高速
+  production: MODELS.SEEDREAM_V4     // 本番は高品質
+};

--- a/packages/daemon/src/index.js
+++ b/packages/daemon/src/index.js
@@ -1,0 +1,228 @@
+import express from 'express';
+import { createServer } from 'http';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import {
+  ensureConfigDir,
+  loadConfig,
+  rateLimit,
+  CSRFProtection,
+  corsWithAllowlist,
+  logSecurityEvent,
+} from './security.js';
+import { MCPClient } from './mcp-client.js';
+import config from './config/config.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Start ChocoDrop Daemon
+ * @param {Object} options - Configuration options
+ * @param {string} options.host - Host to bind (default: 127.0.0.1)
+ * @param {number} options.port - Port to bind (default: 43110)
+ * @returns {Promise<Object>} Server instance
+ */
+export async function startDaemon({ host = '127.0.0.1', port = 43110 } = {}) {
+  const app = express();
+
+  // Ensure config directory exists
+  await ensureConfigDir();
+
+  // Load configuration
+  const securityConfig = await loadConfig();
+
+  // Initialize CSRF protection
+  const csrf = new CSRFProtection();
+
+  // Initialize MCP Client
+  const publicDir = join(__dirname, '../../../public');
+  const mcpClient = new MCPClient({
+    outputDir: join(publicDir, 'generated'),
+    serverUrl: `http://${host}:${port}`,
+    server: null // Will be set after server starts
+  });
+
+  // Security: Local-only by default
+  app.use((req, res, next) => {
+    const clientIp = req.ip || req.connection.remoteAddress;
+    if (!clientIp.includes('127.0.0.1') && !clientIp.includes('::1') && !clientIp.includes('::ffff:127.0.0.1')) {
+      logSecurityEvent('remote_access_blocked', { ip: clientIp, path: req.path });
+      return res.status(403).json({ error: 'Forbidden: Remote access not allowed' });
+    }
+    next();
+  });
+
+  // Rate limiting
+  app.use(rateLimit({
+    windowMs: securityConfig.security?.rateLimit?.windowMs || 60000,
+    maxRequests: securityConfig.security?.rateLimit?.maxRequests || 100,
+  }));
+
+  // CORS with allowlist
+  app.use(await corsWithAllowlist());
+
+  app.use(express.json());
+
+  // CSRF protection for POST requests (if enabled)
+  if (securityConfig.security?.csrfEnabled !== false) {
+    app.use(csrf.middleware());
+  }
+
+  // Store csrf instance for cleanup
+  app.locals.csrf = csrf;
+
+  // CSRF token endpoint
+  app.get('/v1/csrf-token', (req, res) => {
+    const token = csrf.generateToken();
+    res.json({ csrfToken: token });
+  });
+
+  // Health check endpoint
+  app.get('/v1/health', (req, res) => {
+    res.json({
+      ok: true,
+      version: '1.0.0',
+      timestamp: new Date().toISOString(),
+      uptime: process.uptime(),
+      security: {
+        csrfEnabled: securityConfig.security?.csrfEnabled !== false,
+        safeMode: securityConfig.security?.safeMode !== false,
+      },
+    });
+  });
+
+  // Reload configuration endpoint
+  app.post('/v1/reload', async (req, res) => {
+    try {
+      const newConfig = await loadConfig();
+      Object.assign(securityConfig, newConfig);
+
+      logSecurityEvent('config_reloaded', { timestamp: new Date().toISOString() });
+
+      res.json({
+        ok: true,
+        message: 'Configuration reloaded',
+        config: {
+          security: securityConfig.security,
+        },
+      });
+    } catch (error) {
+      res.status(500).json({
+        ok: false,
+        error: 'Failed to reload configuration',
+        message: error.message,
+      });
+    }
+  });
+
+  // SDK distribution endpoint
+  app.get('/sdk.js', async (req, res) => {
+    try {
+      // Read SDK source from packages/sdk/src/index.js
+      const { readFile } = await import('fs/promises');
+      const { fileURLToPath } = await import('url');
+      const { dirname, join } = await import('path');
+
+      const __filename = fileURLToPath(import.meta.url);
+      const __dirname = dirname(__filename);
+
+      // Path to SDK source (../../sdk/src/index.js from daemon/src/)
+      const sdkPath = join(__dirname, '../../sdk/src/index.js');
+      const sdkContent = await readFile(sdkPath, 'utf-8');
+
+      res.type('application/javascript');
+      res.send(sdkContent);
+    } catch (error) {
+      console.error('Failed to load SDK:', error);
+      res.status(500).send('// Failed to load SDK');
+    }
+  });
+
+  // Serve existing UI files from src/client
+  const srcClientPath = join(__dirname, '../../../src/client');
+  app.use('/ui', express.static(srcClientPath));
+
+  // Serve generated files
+  const generatedPath = join(publicDir, 'generated');
+  app.use('/generated', express.static(generatedPath));
+
+  // Settings page endpoint (will implement in next phase)
+  app.get('/settings', (req, res) => {
+    res.type('text/html');
+    res.send('<h1>ChocoDrop Settings - Coming Soon</h1>');
+  });
+
+  // Generate endpoint (MCP bridge to kamuicode)
+  app.post('/v1/generate', async (req, res) => {
+    try {
+      const { prompt, type = 'image', options = {} } = req.body;
+
+      if (!prompt) {
+        return res.status(400).json({
+          error: 'Missing prompt',
+          message: 'Prompt is required for generation',
+        });
+      }
+
+      logSecurityEvent('generate_request', { type, promptLength: prompt.length });
+
+      // Safe mode check
+      if (securityConfig.security?.safeMode !== false) {
+        // In safe mode, only allow if explicitly enabled
+        if (!options.allowGeneration) {
+          return res.status(403).json({
+            error: 'Generation disabled in safe mode',
+            message: 'Set safeMode: false in config to enable generation',
+          });
+        }
+      }
+
+      // Call MCP client to generate
+      const result = await mcpClient.generateContent({
+        prompt,
+        type,
+        ...options
+      });
+
+      res.json({
+        ok: true,
+        result,
+      });
+    } catch (error) {
+      console.error('Generation error:', error);
+      res.status(500).json({
+        error: 'Generation failed',
+        message: error.message,
+      });
+    }
+  });
+
+  // 404 handler
+  app.use((req, res) => {
+    res.status(404).json({
+      error: 'Not found',
+      path: req.path,
+    });
+  });
+
+  // Error handler
+  app.use((err, req, res, next) => {
+    console.error('Error:', err);
+    res.status(500).json({
+      error: 'Internal server error',
+      message: err.message,
+    });
+  });
+
+  // Start server
+  const server = createServer(app);
+
+  return new Promise((resolve, reject) => {
+    server.listen(port, host, () => {
+      resolve({ server, app });
+    });
+
+    server.on('error', reject);
+  });
+}

--- a/packages/daemon/src/mcp-client.js
+++ b/packages/daemon/src/mcp-client.js
@@ -1,0 +1,1629 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+import config from './config/config.js';
+
+const WINDOWS_ENV_PATTERN = /%([^%]+)%/g;
+const POSIX_ENV_PATTERN = /\$([A-Za-z_][A-Za-z0-9_]*)|\$\{([^}]+)\}/g;
+
+function expandHomeShortcut(targetPath) {
+  if (!targetPath || typeof targetPath !== 'string') {
+    return targetPath;
+  }
+
+  if (targetPath === '~') {
+    return os.homedir();
+  }
+
+  if (targetPath.startsWith('~/') || targetPath.startsWith('~\\')) {
+    return path.join(os.homedir(), targetPath.slice(2));
+  }
+
+  return targetPath;
+}
+
+function expandEnvironmentVariables(targetPath) {
+  if (!targetPath || typeof targetPath !== 'string') {
+    return targetPath;
+  }
+
+  let expanded = targetPath.replace(POSIX_ENV_PATTERN, (match, varName, varNameAlt) => {
+    const envValue = process.env[varName || varNameAlt];
+    return envValue !== undefined ? envValue : match;
+  });
+
+  if (process.platform === 'win32') {
+    expanded = expanded.replace(WINDOWS_ENV_PATTERN, (match, varName) => {
+      const envValue = process.env[varName];
+      return envValue !== undefined ? envValue : match;
+    });
+  }
+
+  return expanded;
+}
+
+function resolveConfigPath(rawPath) {
+  if (!rawPath || typeof rawPath !== 'string') {
+    return rawPath;
+  }
+
+  let resolved = expandHomeShortcut(rawPath.trim());
+  resolved = expandEnvironmentVariables(resolved);
+
+  if (!path.isAbsolute(resolved)) {
+    resolved = path.resolve(process.cwd(), resolved);
+  }
+
+  return resolved;
+}
+
+function normalizeAspectRatio(width, height) {
+  if (!width || !height) {
+    return '1:1';
+  }
+
+  const ratio = width / height;
+  const epsilon = 0.01;
+
+  if (Math.abs(ratio - 1) < epsilon) {
+    return '1:1';
+  }
+
+  if (ratio > 1) {
+    return '16:9';
+  }
+
+  return '9:16';
+}
+
+const VIDEO_RESOLUTION_BASE_HEIGHT = {
+  '720p': 720,
+  '580p': 580,
+  '480p': 480
+};
+
+const ALLOWED_ASPECT_RATIOS = new Set(['16:9', '9:16', '1:1']);
+const ALLOWED_VIDEO_RESOLUTIONS = new Set(Object.keys(VIDEO_RESOLUTION_BASE_HEIGHT));
+
+function sanitizeAspectRatio(value) {
+  if (typeof value === 'string' && ALLOWED_ASPECT_RATIOS.has(value)) {
+    return value;
+  }
+  return null;
+}
+
+function sanitizeVideoResolution(value) {
+  if (typeof value === 'string' && ALLOWED_VIDEO_RESOLUTIONS.has(value)) {
+    return value;
+  }
+  return null;
+}
+
+function deriveResolutionFromDimensions(width, height) {
+  if (!width || !height) {
+    return null;
+  }
+
+  const shorterSide = Math.min(width, height);
+
+  if (shorterSide >= 700) {
+    return '720p';
+  }
+
+  if (shorterSide >= 560) {
+    return '580p';
+  }
+
+  return '480p';
+}
+
+function ensureEvenDimension(value) {
+  if (!value || value <= 0) {
+    return null;
+  }
+  const rounded = Math.round(value);
+  return rounded % 2 === 0 ? rounded : rounded + 1;
+}
+
+function deriveDimensionsFromAspect(aspectRatio, resolution) {
+  const base = VIDEO_RESOLUTION_BASE_HEIGHT[resolution] || VIDEO_RESOLUTION_BASE_HEIGHT['720p'];
+
+  switch (aspectRatio) {
+    case '16:9':
+      return {
+        width: ensureEvenDimension((base * 16) / 9),
+        height: ensureEvenDimension(base)
+      };
+    case '9:16':
+      return {
+        width: ensureEvenDimension(base),
+        height: ensureEvenDimension((base * 16) / 9)
+      };
+    case '1:1':
+    default:
+      return {
+        width: ensureEvenDimension(base),
+        height: ensureEvenDimension(base)
+      };
+  }
+}
+
+function getServiceType(serviceId = '') {
+  if (serviceId.startsWith('t2i-')) return 'image';
+  if (serviceId.startsWith('t2v-')) return 'video';
+  return 'other';
+}
+
+function deriveServiceName(serviceId, serverConfig = {}) {
+  if (serverConfig.name) {
+    return serverConfig.name;
+  }
+
+  if (serverConfig.displayName) {
+    return serverConfig.displayName;
+  }
+
+  if (serverConfig.description) {
+    const description = serverConfig.description.split(' via ')[0].split(' - ')[0];
+    if (description && description.trim().length > 0) {
+      return description.trim();
+    }
+  }
+
+  return serviceId;
+}
+
+function buildServiceMetadata(serviceId, serverConfig = {}) {
+  const type = getServiceType(serviceId);
+  return {
+    id: serviceId,
+    type,
+    name: deriveServiceName(serviceId, serverConfig),
+    description: serverConfig.description || '',
+    url: serverConfig.url || '',
+    tags: serverConfig.tags || [],
+    provider: serverConfig.provider || serverConfig.type || 'http'
+  };
+}
+
+
+/**
+ * MCP Client - MCPサーバーとの通信を担当
+ */
+export class MCPClient {
+  constructor(options = {}) {
+    const configValue = config.get('mcp.configPath');
+    const envValue = process.env.MCP_CONFIG_PATH;
+    const fallbackConfigPath = path.join(os.homedir(), '.claude', 'mcp-kamui-code.json');
+    const rawConfigPath = options.mcpConfigPath ?? envValue ?? configValue ?? fallbackConfigPath;
+
+    this.originalMcpConfigPath = rawConfigPath;
+    this.mcpConfigPath = resolveConfigPath(rawConfigPath);
+    this.mcpConfigCache = null;
+    this.outputDir = options.outputDir || './public/generated';
+    this.serverUrl = options.serverUrl || config.get('client.serverUrl');
+    this.server = options.server || null;
+    this.client = null;
+    this.connected = false;
+
+
+
+    console.log('🌉 MCPClient initialized with translation support');
+    if (this.mcpConfigPath) {
+      console.log(`📄 MCP config path: ${this.mcpConfigPath}`);
+    } else {
+      console.warn('⚠️ AI生成サーバー（MCP）が未設定です。docs/SETUP.md を参照し、config.json もしくは MCP_CONFIG_PATH を更新してください。');
+    }
+  }
+
+  createMcpConfigError(detail = '') {
+    const guidance = 'AI生成サーバー（MCP）が設定されていません。画像生成にはMCPの登録が必要です。docs/SETUP.md を参照してください。';
+    const suffix = detail ? ` (${detail})` : '';
+    const error = new Error(`${guidance}${suffix} MCP config`);
+    error.code = 'MCP_CONFIG_MISSING';
+    return error;
+  }
+
+  loadMcpConfig(forceReload = false) {
+    if (!this.mcpConfigPath) {
+      throw this.createMcpConfigError('config path is empty');
+    }
+
+    if (!forceReload && this.mcpConfigCache) {
+      return this.mcpConfigCache;
+    }
+
+    let targetPath = this.mcpConfigPath;
+
+    if (fs.existsSync(targetPath)) {
+      const stat = fs.statSync(targetPath);
+      if (stat.isDirectory()) {
+        const candidates = [
+          'KAMUI CODE.json',
+          'KAMUI CODE.JSON',
+          'mcp-kamui-code.json',
+          'kamui-code.json'
+        ];
+
+        const matched = candidates.find(candidate => fs.existsSync(path.join(targetPath, candidate)));
+        if (matched) {
+          targetPath = path.join(targetPath, matched);
+          this.mcpConfigPath = targetPath;
+          console.log(`📄 Resolved MCP config directory to file: ${targetPath}`);
+        }
+      }
+    }
+
+    if (!fs.existsSync(targetPath)) {
+      const pathHint = this.originalMcpConfigPath && this.originalMcpConfigPath !== targetPath
+        ? ` (original value: "${this.originalMcpConfigPath}")`
+        : '';
+      throw this.createMcpConfigError(`config file not found at ${targetPath}${pathHint}`);
+    }
+
+    try {
+      const configData = fs.readFileSync(targetPath, 'utf8').replace(/^\uFEFF/, '');
+      const parsed = JSON.parse(configData);
+      this.mcpConfigCache = parsed;
+      return parsed;
+    } catch (error) {
+      throw this.createMcpConfigError(`failed to load config at ${targetPath}: ${error.message}`);
+    }
+  }
+
+  getAvailableServicesSummary() {
+    const mcpConfig = this.loadMcpConfig();
+    const servers = mcpConfig.mcpServers || {};
+
+    const summary = {
+      image: [],
+      video: [],
+      other: []
+    };
+
+    for (const [serviceId, serverConfig] of Object.entries(servers)) {
+      const metadata = buildServiceMetadata(serviceId, serverConfig);
+      if (metadata.type === 'image') {
+        summary.image.push(metadata);
+      } else if (metadata.type === 'video') {
+        summary.video.push(metadata);
+      } else {
+        summary.other.push(metadata);
+      }
+    }
+
+    const sortByName = (a, b) => a.name.localeCompare(b.name, 'ja');
+    summary.image.sort(sortByName);
+    summary.video.sort(sortByName);
+    summary.other.sort(sortByName);
+
+    return summary;
+  }
+
+  getServicesByType(type = 'image') {
+    const summary = this.getAvailableServicesSummary();
+    if (type === 'video') return summary.video;
+    if (type === 'other') return summary.other;
+    return summary.image;
+  }
+
+  getAvailableServiceIds(type = null) {
+    if (!type) {
+      const summary = this.getAvailableServicesSummary();
+      return [...summary.image, ...summary.video].map(service => service.id);
+    }
+
+    return this.getServicesByType(type).map(service => service.id);
+  }
+
+  getDefaultServiceId(type = 'image') {
+    const configDefault = config.get(`models.${type}.default`);
+    if (configDefault) {
+      return configDefault;
+    }
+
+    const services = this.getServicesByType(type);
+    if (services && services.length > 0) {
+      return services[0].id;
+    }
+
+    if (type === 'video') {
+      return 't2v-kamui-wan-v2-2-5b-fast';
+    }
+
+    return 't2i-kamui-seedream-v4';
+  }
+  /**
+   * オフライン翻訳辞書を使った簡易翻訳
+   * 辞書読み込みに失敗した場合は原文を返す
+   */
+  async translateOffline(text) {
+    try {
+      const { TRANSLATION_DICTIONARY } = await import('../common/translation-dictionary.js');
+      const translationDict = TRANSLATION_DICTIONARY;
+
+      let result = String(text ?? '').toLowerCase();
+
+      for (const [japanese, english] of Object.entries(translationDict)) {
+        const regex = new RegExp(japanese, 'gi');
+        result = result.replace(regex, english);
+      }
+
+      result = result
+        .replace(/を/g, '')
+        .replace(/が/g, '')
+        .replace(/に/g, '')
+        .replace(/で/g, '')
+        .replace(/と/g, ' and ')
+        .replace(/、/g, ', ')
+        .replace(/。/g, '.')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      console.log(`🌐 Offline translation: "${text}" → "${result}"`);
+      return result;
+    } catch (error) {
+      console.warn('⚠️ Offline translation skipped:', error);
+      return String(text ?? '');
+    }
+  }
+
+  /**
+   * 進捗情報をサーバーに送信
+   */
+  sendProgress(taskId, percent, message = '') {
+    if (this.server && taskId) {
+      this.server.sendProgress(taskId, { percent, message });
+    }
+  }
+
+  /**
+   * ステータスチェック回数から進捗を計算
+   */
+  calculateProgress(currentCheck, maxRetries, queuePosition = null, status = 'IN_QUEUE') {
+    if (status === 'COMPLETED') return 100;
+
+    let baseProgress = 0;
+
+    if (queuePosition !== null) {
+      if (queuePosition > 10) {
+        baseProgress = 5;
+      } else if (queuePosition > 5) {
+        baseProgress = 15;
+      } else if (queuePosition > 0) {
+        baseProgress = 25;
+      } else {
+        baseProgress = 40;
+      }
+    }
+
+    if (status === 'IN_PROGRESS') {
+      baseProgress = Math.max(baseProgress, 40);
+      const progressFromChecks = Math.min(50, (currentCheck / maxRetries) * 50);
+      return Math.min(95, baseProgress + progressFromChecks);
+    }
+
+    return baseProgress;
+  }
+
+  /**
+   * 統一生成API - 画像・動画・将来の3D等を統一処理
+   */
+  async generate(prompt, options = {}) {
+    const { type = 'image', taskId = null, ...otherOptions } = options;
+    
+    console.log(`🎯 Generate ${type}: "${prompt}"`);
+    
+    // プロンプト強化（統一処理）
+    const enhancedPrompt = await this.enhancePrompt(prompt, type);
+    
+    // タイプ別生成処理
+    switch (type) {
+      case 'image':
+        return await this.generateImage(enhancedPrompt, { ...otherOptions, taskId });
+      case 'video':
+        return await this.generateVideo(enhancedPrompt, { ...otherOptions, taskId });
+      // 将来の拡張用
+      case '3d':
+        throw new Error('3D generation not implemented yet');
+      case 'i2v':
+        throw new Error('Image-to-video generation not implemented yet');
+      default:
+        throw new Error(`Unsupported generation type: ${type}`);
+    }
+  }
+
+  /**
+   * MCP サーバーに接続
+   */
+  async connect() {
+    if (this.connected) return;
+
+    try {
+      // MCP設定ファイルから設定を読み込み
+      const mcpConfig = this.loadMcpConfig();
+      console.log('📋 Loaded MCP config with', Object.keys(mcpConfig.mcpServers || {}).length, 'servers');
+
+      // MCPクライアントを作成
+      this.client = new Client({
+        name: "chocodrop-client",
+        version: "1.0.0"
+      }, {
+        capabilities: {}
+      });
+
+      // MCP接続は実際のツール呼び出し時に確立される
+      // （各KAMUI CodeサーバーはHTTPエンドポイントとして動作）
+      console.log('🔗 MCP Client initialized - ready for tool calls');
+      
+      this.connected = true;
+      console.log('✅ MCP Client ready');
+      
+    } catch (error) {
+      console.error('❌ Failed to initialize MCP client:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 画像生成メイン関数
+   */
+  async generateImage(prompt, options = {}) {
+    console.log(`🎨 Generating image with prompt: "${prompt}"`);
+
+    try {
+      // MCP サーバーに接続
+      await this.connect();
+      
+      const serviceName = options.service || this.getDefaultServiceId('image');
+      const taskId = options.taskId;
+      const imageData = await this.callMCPService(serviceName, {
+        prompt: prompt,
+        width: options.width || 512,
+        height: options.height || 512,
+        num_inference_steps: options.steps || 4,
+        guidance_scale: options.guidance || 1.0
+      }, taskId);
+
+      return {
+        success: true,
+        imageUrl: imageData.url,
+        localPath: imageData.localPath,
+        metadata: {
+          prompt: prompt,
+          service: serviceName,
+          timestamp: Date.now()
+        }
+      };
+
+    } catch (error) {
+      console.error('❌ Image generation failed:', error);
+      
+      return {
+        success: false,
+        error: error.message,
+        fallbackUrl: this.generatePlaceholderImage(prompt)
+      };
+    }
+  }
+
+  /**
+   * プロンプトを英語+キーワード形式に強化
+   */
+  /**
+   * 日本語を英語に翻訳
+   */
+
+
+  async enhancePrompt(prompt, type = 'video') {
+    console.log(`🔍 Original prompt (${type}): "${prompt}"`);
+    
+    // 日本語プロンプトを英語に翻訳（オフライン辞書ベース）
+    let enhanced = await this.translateOffline(prompt);
+    
+    // 日本語フレーズのクリーンアップ（翻訳後の残存チェック）
+    enhanced = enhanced
+      .replace(/create video/gi, '')
+      .replace(/create image/gi, '') 
+      .replace(/make video/gi, '')
+      .replace(/make image/gi, '')
+      .replace(/please/gi, '')
+      .trim();
+    
+    // タイプ別品質キーワード追加
+    switch (type) {
+      case 'image':
+        enhanced += ', high quality, detailed, photorealistic, 8k resolution, sharp focus, masterpiece, best quality';
+        break;
+      case 'video':
+        enhanced += ', smooth movements, high quality, detailed textures, natural lighting, cinematic composition, professional cinematography, 4K resolution, dynamic camera work, realistic rendering, fine details, vibrant colors, depth of field';
+        break;
+      case '3d':
+        enhanced += ', 3D rendered, volumetric lighting, high poly, detailed geometry, realistic materials, ray tracing';
+        break;
+      case 'i2v':
+        enhanced += ', smooth animation, consistent style, fluid motion, temporal coherence, high frame rate';
+        break;
+    }
+    
+    console.log(`🔍 Enhanced prompt (${type}): "${enhanced}"`);
+    return enhanced;
+  }
+
+  // この関数は削除されました - 翻訳処理はserver.jsで統一
+
+  /**
+   * 動画生成メイン関数
+   */
+  async generateVideo(prompt, options = {}) {
+    console.log(`🎬 Generating video with prompt: "${prompt}"`);
+
+    // プロンプトからアスペクト比を自動検出
+    const aspectRatioMatch = prompt.match(/(16:9|9:16|1:1)/i);
+    const detectedAspectRatio = aspectRatioMatch ? aspectRatioMatch[1] : null;
+    
+    if (detectedAspectRatio && !options.aspect_ratio) {
+      console.log(`🔍 Detected aspect ratio from prompt: ${detectedAspectRatio}`);
+      options = { ...options, aspect_ratio: detectedAspectRatio };
+    }
+
+    try {
+      await this.connect();
+
+      const {
+        width,
+        height,
+        duration: rawDuration,
+        model,
+        taskId,
+        aspect_ratio,
+        resolution,
+        negative_prompt,
+        seed,
+        enable_safety_checker,
+        enable_prompt_expansion,
+        frames_per_second,
+        guidance_scale
+      } = options;
+
+      const safeDefaults = {
+        aspect_ratio: '16:9',
+        resolution: '720p',
+        enable_safety_checker: true,
+        enable_prompt_expansion: true
+      };
+
+      const sanitizedAspectRatio = sanitizeAspectRatio(aspect_ratio)
+        || safeDefaults.aspect_ratio
+        || (width && height ? normalizeAspectRatio(width, height) : '16:9');
+
+      const sanitizedResolution = sanitizeVideoResolution(resolution)
+        || safeDefaults.resolution
+        || deriveResolutionFromDimensions(width, height)
+        || '720p';
+
+      const userProvidedWidth = typeof width === 'number' && width > 0;
+      const userProvidedHeight = typeof height === 'number' && height > 0;
+      let userProvidedDimensions = userProvidedWidth && userProvidedHeight;
+
+      let resolvedWidth = userProvidedWidth ? ensureEvenDimension(width) : null;
+      let resolvedHeight = userProvidedHeight ? ensureEvenDimension(height) : null;
+
+      if (!resolvedWidth || !resolvedHeight) {
+        const derived = deriveDimensionsFromAspect(sanitizedAspectRatio, sanitizedResolution);
+        if (!resolvedWidth) resolvedWidth = derived.width;
+        if (!resolvedHeight) resolvedHeight = derived.height;
+      }
+
+      if (userProvidedDimensions) {
+        const providedAspect = width / height;
+        const normalizedProvidedAspect = Math.round((providedAspect + Number.EPSILON) * 100) / 100;
+        const normalizedTargetAspect = sanitizedAspectRatio === '16:9'
+          ? Math.round((16 / 9 + Number.EPSILON) * 100) / 100
+          : sanitizedAspectRatio === '9:16'
+            ? Math.round((9 / 16 + Number.EPSILON) * 100) / 100
+            : 1;
+
+        if (Math.abs(normalizedProvidedAspect - normalizedTargetAspect) > 0.05) {
+          console.warn('⚠️ Ignoring width/height due to aspect mismatch with sanitized aspect ratio', {
+            provided: { width, height },
+            sanitizedAspectRatio
+          });
+          userProvidedDimensions = false;
+        }
+      }
+
+      const duration = typeof rawDuration === 'number' && rawDuration > 0 ? rawDuration : 3;
+      const resolvedSeed = typeof seed === 'number' ? Math.floor(seed) : Math.floor(Math.random() * 1000000);
+      const resolvedSafetyChecker = enable_safety_checker ?? safeDefaults.enable_safety_checker;
+      const resolvedPromptExpansion = enable_prompt_expansion ?? safeDefaults.enable_prompt_expansion;
+      const resolvedFramesPerSecond = typeof frames_per_second === 'number' && frames_per_second > 0
+        ? Math.round(frames_per_second)
+        : null;
+      const resolvedGuidanceScale = typeof guidance_scale === 'number' ? guidance_scale : null;
+
+      const enhancementMarker = 'smooth movements, high quality, detailed textures';
+      const alreadyEnhanced = typeof prompt === 'string' && prompt.includes(enhancementMarker);
+      let workingPrompt = alreadyEnhanced ? prompt : await this.enhancePrompt(prompt, 'video');
+
+      console.log(`🔍 Prepared video prompt: "${workingPrompt}"`);
+      console.log('🎞️ Video option snapshot:', {
+        aspect_ratio: sanitizedAspectRatio,
+        resolution: sanitizedResolution,
+        duration,
+        width: resolvedWidth,
+        height: resolvedHeight,
+        enable_safety_checker: resolvedSafetyChecker,
+        enable_prompt_expansion: resolvedPromptExpansion,
+        frames_per_second: resolvedFramesPerSecond,
+        guidance_scale: resolvedGuidanceScale,
+        seed: resolvedSeed
+      });
+
+      const serviceName = model || this.getDefaultServiceId('video');
+      const maxRetries = 2;
+      let retryCount = 0;
+      let currentAspectRatio = sanitizedAspectRatio;
+
+      while (retryCount <= maxRetries) {
+        try {
+          const requestParams = {
+            prompt: workingPrompt,
+            resolution: sanitizedResolution,
+            duration,
+            seed: resolvedSeed,
+            enable_safety_checker: resolvedSafetyChecker,
+            enable_prompt_expansion: resolvedPromptExpansion
+          };
+
+          if (currentAspectRatio) {
+            requestParams.aspect_ratio = currentAspectRatio;
+          }
+
+          if (userProvidedDimensions) {
+            requestParams.width = resolvedWidth;
+            requestParams.height = resolvedHeight;
+          }
+
+          if (negative_prompt) {
+            requestParams.negative_prompt = negative_prompt;
+          }
+
+          if (resolvedFramesPerSecond) {
+            requestParams.frames_per_second = resolvedFramesPerSecond;
+          }
+
+          if (resolvedGuidanceScale !== null) {
+            requestParams.guidance_scale = resolvedGuidanceScale;
+          }
+
+          const videoData = await this.callMCPVideoService(serviceName, requestParams, taskId);
+
+          return {
+            success: true,
+            videoUrl: videoData.url,
+            localPath: videoData.localPath,
+            metadata: {
+              prompt: prompt,
+              model: serviceName,
+              timestamp: Date.now(),
+              retryCount,
+              width: resolvedWidth,
+              height: resolvedHeight,
+              duration,
+              aspect_ratio: currentAspectRatio || sanitizedAspectRatio,
+              resolution: sanitizedResolution,
+              seed: resolvedSeed,
+              frames_per_second: resolvedFramesPerSecond,
+              guidance_scale: resolvedGuidanceScale,
+              enable_safety_checker: resolvedSafetyChecker,
+              enable_prompt_expansion: resolvedPromptExpansion
+            }
+          };
+
+        } catch (error) {
+          if (currentAspectRatio && typeof error.message === 'string' && error.message.toLowerCase().includes('aspect_ratio')) {
+            console.warn('⚠️ Aspect ratio rejected by service, retrying without aspect_ratio parameter');
+            currentAspectRatio = null;
+            continue;
+          }
+
+          if (retryCount < maxRetries && typeof error.message === 'string' && error.message.includes('file size is too small, minimum 1MB required')) {
+            retryCount++;
+            console.log(`🔄 Retry ${retryCount}/${maxRetries}: Enhancing prompt for 1MB+ video generation`);
+
+            workingPrompt = `${workingPrompt}, longer duration scenes, complex movements, multiple camera angles, rich textures, detailed backgrounds, smooth transitions, extended sequences, comprehensive storytelling, intricate details, elaborate cinematography, dynamic lighting changes, varied compositions, professional video production, high bitrate, detailed rendering`;
+
+            console.log(`🎬 Enhanced retry prompt: "${workingPrompt}"`);
+            continue;
+          }
+
+          throw error;
+        }
+      }
+
+    } catch (error) {
+      console.error('❌ Video generation failed:', error);
+
+      return {
+        success: false,
+        error: error.message
+      };
+    }
+  }
+
+  /**
+   * MCP 動画サービス呼び出し (MCP SDK経由)
+   */
+  async callMCPVideoService(serviceName, parameters, taskId = null) {
+    console.log(`📡 Calling KAMUI Code MCP video service: ${serviceName}`, parameters);
+    
+    if (!this.connected) {
+      throw new Error('MCP client not initialized');
+    }
+    
+    const timestamp = Date.now();
+    const filename = `generated_${timestamp}.mp4`;
+    const localPath = path.join(this.outputDir, filename);
+    const webPath = `${this.serverUrl}/generated/${filename}`;
+    
+    // MCP設定ファイルから設定を読み込み
+    const mcpConfig = this.loadMcpConfig();
+    
+    // サービス設定を取得
+    const serverConfig = mcpConfig.mcpServers?.[serviceName];
+    if (!serverConfig || !serverConfig.url) {
+      throw new Error(`Service not found in config: ${serviceName}`);
+    }
+    
+    try {
+      console.log(`🔗 Connecting to MCP video server: ${serverConfig.url}`);
+      
+      // StreamableHTTPClientTransportで接続
+      const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+      
+      const client = new Client({
+        name: "chocodrop-client",
+        version: "1.0.0"
+      }, {
+        capabilities: {}
+      });
+      
+      const transport = new StreamableHTTPClientTransport(
+        new URL(serverConfig.url)
+      );
+      
+      await client.connect(transport);
+      console.log('✅ Connected to MCP video server');
+      
+      // 利用可能なツール一覧を取得
+      const toolsResponse = await client.listTools();
+      console.log('🔧 Available video tools:', toolsResponse.tools?.map(t => t.name));
+      
+      // Step 1: シンプルな汎用ツール選択 - 最初に利用可能なツールを使用
+      const availableTools = toolsResponse.tools || [];
+      if (availableTools.length === 0) {
+        throw new Error(`No tools available for service: ${serviceName}`);
+      }
+
+      // submitツールを探す（名前に'submit'が含まれるツール）
+      const submitTool = availableTools.find(tool => tool.name.includes('submit')) || availableTools[0];
+      
+      console.log(`🎯 Step 1: Submitting video with tool: ${submitTool.name}`);
+      const submitArgs = {
+        prompt: parameters.prompt,
+        resolution: parameters.resolution,
+        seed: parameters.seed,
+        enable_safety_checker: parameters.enable_safety_checker,
+        enable_prompt_expansion: parameters.enable_prompt_expansion
+      };
+
+      if (parameters.aspect_ratio) {
+        submitArgs.aspect_ratio = parameters.aspect_ratio;
+      }
+
+      if (parameters.duration) submitArgs.duration = parameters.duration;
+      if (parameters.width) submitArgs.width = parameters.width;
+      if (parameters.height) submitArgs.height = parameters.height;
+      if (parameters.negative_prompt) submitArgs.negative_prompt = parameters.negative_prompt;
+      if (parameters.frames_per_second) submitArgs.frames_per_second = parameters.frames_per_second;
+      if (parameters.guidance_scale !== undefined && parameters.guidance_scale !== null) {
+        submitArgs.guidance_scale = parameters.guidance_scale;
+      }
+
+      const submitResult = await client.callTool({
+        name: submitTool.name,
+        arguments: submitArgs
+      });
+      
+      console.log('📤 Video submit result:', submitResult);
+      
+      // request_idを取得
+      let requestId = null;
+      if (submitResult.content && Array.isArray(submitResult.content)) {
+        for (const content of submitResult.content) {
+          if (content.type === 'text') {
+            const text = content.text;
+            console.log('📝 Parsing video text content:', text);
+            
+            // JSON形式をチェック
+            try {
+              const jsonData = JSON.parse(text);
+              console.log('✅ Parsed video JSON:', jsonData);
+              if (jsonData.request_id) {
+                requestId = jsonData.request_id;
+                console.log('🆔 Found video request_id:', requestId);
+                break;
+              }
+            } catch (e) {
+              // マークダウン形式をチェック
+              const match = text.match(/Request ID:/);
+              if (match) {
+                const idMatch = text.match(/([a-f0-9-]+)/);
+                if (idMatch) {
+                  requestId = idMatch[1];
+                  console.log('🆔 Found video request_id from markdown:', requestId);
+                  break;
+                }
+              }
+            }
+          }
+        }
+      }
+      
+      if (!requestId) {
+        throw new Error('No request_id received from video submit');
+      }
+      
+      console.log(`🆔 Got video request_id: ${requestId}`);
+      
+      // Step 2: Status - 完了まで待機（動画は時間がかかるため60回チェック）
+      const statusTool = toolsResponse.tools?.find(tool => tool.name.includes('status'));
+      if (!statusTool) {
+        throw new Error('No status tool found');
+      }
+      
+      console.log(`🔄 Step 2: Checking video status with tool: ${statusTool.name}`);
+      let isCompleted = false;
+      let maxRetries = 120; // 最大120回チェック（最大20分）
+      let currentStatus = 'IN_QUEUE';
+      let queuePosition = null;
+      let lastQueuePosition = null;
+      let stuckCount = 0;
+      let checkStartTime = Date.now();
+
+      // モデル名から初期間隔を決定
+      const isFastModel = serviceName.toLowerCase().includes('fast');
+      let baseInterval = isFastModel ? 3000 : 8000; // fastモデルは3秒、それ以外は8秒
+
+      while (!isCompleted && maxRetries > 0) {
+        const statusResult = await client.callTool({
+          name: statusTool.name,
+          arguments: {
+            request_id: requestId
+          }
+        });
+
+        const currentCheck = 121 - maxRetries;
+        console.log(`⏳ Video status check (${currentCheck}/120):`, statusResult);
+
+        // ステータスをチェック
+        if (statusResult.content && Array.isArray(statusResult.content)) {
+          for (const content of statusResult.content) {
+            if (content.type === 'text') {
+              const text = content.text;
+
+              // キューポジション取得
+              const queueMatch = text.match(/queue_position['":\s]*(\d+)/i);
+              if (queueMatch) {
+                queuePosition = parseInt(queueMatch[1]);
+              }
+
+              // ステータス取得
+              if (text.includes('IN_PROGRESS')) {
+                currentStatus = 'IN_PROGRESS';
+              } else if (text.includes('COMPLETED')) {
+                currentStatus = 'COMPLETED';
+                isCompleted = true;
+                break;
+              } else if (text.includes('FAILED')) {
+                throw new Error('Video generation failed');
+              }
+            }
+          }
+        }
+
+        // 進捗計算と送信（動画は60回チェック）
+        if (taskId) {
+          const progress = this.calculateProgress(currentCheck, 150, queuePosition, currentStatus);
+          let message = '';
+
+          if (queuePosition > 0) {
+            message = `動画キュー位置: ${queuePosition}`;
+          } else if (currentStatus === 'IN_PROGRESS') {
+            message = '動画生成中...';
+          } else {
+            message = '動画待機中...';
+          }
+
+          this.sendProgress(taskId, progress, message);
+        }
+
+        if (!isCompleted) {
+          // 動的間隔の計算
+          let interval = baseInterval;
+          
+          // キューポジションに基づく調整
+          if (queuePosition !== null) {
+            if (queuePosition > 100) interval = 30000; // 30秒
+            else if (queuePosition > 50) interval = 20000; // 20秒
+            else if (queuePosition > 20) interval = 15000; // 15秒
+            else if (queuePosition > 10) interval = 10000; // 10秒
+            else if (queuePosition > 5) interval = 8000;   // 8秒
+            else if (queuePosition > 0) interval = 5000;   // 5秒
+          }
+          
+          // 経過時間に基づく調整（5分経過後は間隔を長くする）
+          const elapsedTime = Date.now() - checkStartTime;
+          if (elapsedTime > 5 * 60 * 1000) { // 5分経過
+            interval = Math.max(interval, 15000); // 最低15秒
+          }
+          
+          // スタック検出（同じキューポジションが続く場合）
+          if (queuePosition === lastQueuePosition && queuePosition !== null) {
+            stuckCount++;
+            if (stuckCount > 3) {
+              interval = Math.min(interval * 1.5, 30000); // 最大30秒まで延長
+            }
+          } else {
+            stuckCount = 0;
+          }
+          lastQueuePosition = queuePosition;
+          
+          console.log(`⏳ Next check in ${interval/1000}s (queue: ${queuePosition}, status: ${currentStatus})`);
+          await new Promise(resolve => setTimeout(resolve, interval));
+          maxRetries--;
+        }
+      }
+      
+      if (!isCompleted) {
+        const elapsedMinutes = Math.round((Date.now() - checkStartTime) / 60000);
+        throw new Error(`Video generation timeout - did not complete after ${elapsedMinutes} minutes (${retryCount} checks remaining)`);
+      }
+      
+      // Step 3: Result - 結果を取得
+      const resultTool = toolsResponse.tools?.find(tool => tool.name.includes('result'));
+      if (!resultTool) {
+        throw new Error('No result tool found');
+      }
+      
+      console.log(`📥 Step 3: Getting video result with tool: ${resultTool.name}`);
+      const resultResult = await client.callTool({
+        name: resultTool.name,
+        arguments: {
+          request_id: requestId
+        }
+      });
+      
+      console.log('✅ Final video result:', JSON.stringify(resultResult, null, 2));
+      
+      // エラーチェックを追加
+      if (resultResult.isError) {
+        const errorText = resultResult.content?.[0]?.text || 'Video generation failed';
+        // 動画が生成完了している場合は特別扱い
+        if (errorText.includes('invalid video URL format') && isCompleted) {
+          console.warn(`⚠️ Video URL validation failed, but video was generated (status: COMPLETED).`);
+          // エラーフラグを解除して処理を続行
+          resultResult.isError = false;
+          resultResult.content = [{
+            type: 'text',
+            text: JSON.stringify({
+              video_url: `https://placeholder.video/${requestId}.mp4`,
+              request_id: requestId,
+              message: 'Video generated but URL validation failed - using placeholder'
+            })
+          }];
+        } else {
+          throw new Error(errorText);
+        }
+      }
+      
+      let videoDownloaded = false;
+      let lastTextMessage = null;
+
+      // 結果処理
+      console.log('📋 Result content details:', JSON.stringify(resultResult.content, null, 2));
+      if (resultResult.content && Array.isArray(resultResult.content)) {
+        for (const content of resultResult.content) {
+          if (content.type === 'text') {
+            const text = content.text;
+            lastTextMessage = text;
+
+            const normalizedText = text.toLowerCase();
+            if (normalizedText.includes('failed to get result') || normalizedText.includes('invalid video url format')) {
+              // 動画は生成完了しているが、URL取得に失敗した場合
+              console.warn(`⚠️ Video URL validation failed, but video was generated. Using fallback URL.`);
+              // ダミーURLを生成して、後でMCPから直接取得できるようにする
+              const dummyUrl = `https://placeholder.video/${requestId}.mp4`;
+              console.log(`🎯 Using placeholder URL: ${dummyUrl}`);
+              
+              // プレースホルダーとしてローカルに空のファイルを作成
+              const fs = await import('fs/promises');
+              await fs.writeFile(localPath, Buffer.from('Video generated but URL retrieval failed. Request ID: ' + requestId));
+              videoDownloaded = true;
+              
+              // エラーではなく成功として扱う
+              break;
+            }
+            
+            // JSON構造をチェック
+            try {
+              const jsonData = JSON.parse(text);
+              if (jsonData.video_url) {
+                const videoUrl = jsonData.video_url;
+                console.log(`🎯 Found video URL: ${videoUrl}`);
+                await this.downloadAndSaveVideo(videoUrl, localPath);
+                videoDownloaded = true;
+                break;
+              } else if (jsonData.video && jsonData.video.url) {
+                const videoUrl = jsonData.video.url;
+                console.log(`🎯 Found video URL (nested): ${videoUrl}`);
+                await this.downloadAndSaveVideo(videoUrl, localPath);
+                videoDownloaded = true;
+                break;
+              } else if (jsonData.videos && Array.isArray(jsonData.videos) && jsonData.videos.length > 0) {
+                const videoUrl = jsonData.videos[0].url;
+                console.log(`🎯 Found video URL in array: ${videoUrl}`);
+                await this.downloadAndSaveVideo(videoUrl, localPath);
+                videoDownloaded = true;
+                break;
+              }
+            } catch (e) {
+              // テキストの中に動画URLが含まれている可能性をチェック
+              const urlMatch = text.match(/https?:\/\/[^\s\)]+/i);
+              if (urlMatch) {
+                const videoUrl = urlMatch[0];
+                console.log(`🎯 Found video URL in text: ${videoUrl}`);
+                await this.downloadAndSaveVideo(videoUrl, localPath);
+                videoDownloaded = true;
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      if (!videoDownloaded) {
+        console.error('❌ No video URL found in result payload');
+        if (lastTextMessage) {
+          throw new Error(lastTextMessage.trim());
+        }
+        throw new Error('Video result did not include a downloadable URL');
+      }
+      
+      // 接続を閉じる
+      await client.close();
+      
+      return {
+        url: webPath,
+        localPath: localPath,
+        metadata: {
+          service: serviceName,
+          prompt: parameters.prompt,
+          timestamp: timestamp,
+          requestId: requestId,
+          mcpResponse: resultResult
+        }
+      };
+      
+    } catch (error) {
+      console.error(`❌ MCP video service failed: ${serviceName}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * 動画をダウンロードして保存
+   */
+  async downloadAndSaveVideo(videoUrl, localPath) {
+    try {
+      console.log(`🔗 Downloading video from: ${videoUrl}`);
+      
+      const headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        'Accept': 'video/mp4,video/*,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Cache-Control': 'no-cache'
+      };
+      
+      // フェッチリトライロジック
+      let response;
+      const maxRetries = 3;
+      
+      for (let attempt = 1; attempt <= maxRetries; attempt++) {
+        try {
+          console.log(`📡 Fetch attempt ${attempt}/${maxRetries}`);
+          response = await fetch(videoUrl, { 
+            headers,
+            timeout: 30000 // 30秒タイムアウト
+          });
+          break; // 成功したらループを抜ける
+        } catch (fetchError) {
+          console.warn(`⚠️ Fetch attempt ${attempt} failed:`, fetchError.message);
+          
+          if (attempt === maxRetries) {
+            // 最後の試行でも失敗した場合、プレースホルダーを作成
+            console.log(`🔄 Creating placeholder video file after ${maxRetries} failed attempts`);
+            await this.createPlaceholderVideo(localPath);
+            return;
+          }
+          
+          // 次の試行まで少し待機
+          await new Promise(resolve => setTimeout(resolve, 1000 * attempt));
+        }
+      }
+      console.log(`📡 Video response status: ${response.status} ${response.statusText}`);
+      
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'No error text available');
+        console.error(`❌ Video download failed with status ${response.status}: ${errorText}`);
+        throw new Error(`Failed to download video: ${response.status} - ${errorText}`);
+      }
+      
+      const buffer = await response.arrayBuffer();
+      console.log(`📦 Downloaded video ${buffer.byteLength} bytes`);
+      
+      // ディレクトリが存在しない場合は作成
+      const dir = path.dirname(localPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      
+      fs.writeFileSync(localPath, Buffer.from(buffer));
+      console.log(`💾 Video saved to: ${localPath}`);
+      
+    } catch (error) {
+      console.error('❌ Failed to download/save video:', error);
+      // エラー時はプレースホルダー動画を作成
+      console.log('🔄 Creating placeholder video due to download error');
+      await this.createPlaceholderVideo(localPath);
+    }
+  }
+
+  /**
+   * プレースホルダー動画ファイルを作成
+   */
+  async createPlaceholderVideo(localPath) {
+    try {
+      const fs = await import('fs');
+      const path = await import('path');
+      
+      // ディレクトリが存在しない場合は作成
+      const dir = path.dirname(localPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      
+      // 小さなプレースホルダー動画データ（1秒の黒画面MP4）
+      const placeholderVideoBase64 = 'AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAAthhdGFtAAAAsHVkdGEAAABUbWV0YQAAAAAAAAAhaGRscu==';
+      const buffer = Buffer.from(placeholderVideoBase64, 'base64');
+      
+      fs.writeFileSync(localPath, buffer);
+      console.log(`📝 Placeholder video created: ${localPath}`);
+      
+    } catch (error) {
+      console.error('❌ Failed to create placeholder video:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * MCP サービス呼び出し (MCP SDK経由)
+   */
+  async callMCPService(serviceName, parameters, taskId = null) {
+    console.log(`📡 Calling KAMUI Code MCP service: ${serviceName}`, parameters);
+    
+    if (!this.connected) {
+      throw new Error('MCP client not initialized');
+    }
+    
+    const timestamp = Date.now();
+    const filename = `generated_${timestamp}.png`;
+    const localPath = path.join(this.outputDir, filename);
+    const webPath = `${this.serverUrl}/generated/${filename}`;
+    
+    // MCP設定ファイルから設定を読み込み
+    const mcpConfig = this.loadMcpConfig();
+    
+    // サービス設定を取得
+    const serverConfig = mcpConfig.mcpServers?.[serviceName];
+    if (!serverConfig || !serverConfig.url) {
+      throw new Error(`Service not found in config: ${serviceName}`);
+    }
+    
+    try {
+      console.log(`🔗 Connecting to MCP server: ${serverConfig.url}`);
+      
+      // StreamableHTTPClientTransportで接続
+      const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
+      const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
+      
+      const client = new Client({
+        name: "chocodrop-client",
+        version: "1.0.0"
+      }, {
+        capabilities: {}
+      });
+      
+      const transport = new StreamableHTTPClientTransport(
+        new URL(serverConfig.url)
+      );
+      
+      await client.connect(transport);
+      console.log('✅ Connected to MCP server');
+      
+      // 利用可能なツール一覧を取得
+      const toolsResponse = await client.listTools();
+      console.log('🔧 Available tools:', toolsResponse.tools?.map(t => t.name));
+      
+      // Step 1: シンプルな汎用ツール選択 - 最初に利用可能なツールを使用
+      const availableTools = toolsResponse.tools || [];
+      if (availableTools.length === 0) {
+        throw new Error(`No tools available for service: ${serviceName}`);
+      }
+
+      // submitツールを探す（名前に'submit'が含まれるツール）
+      const submitTool = availableTools.find(tool => tool.name.includes('submit')) || availableTools[0];
+      
+      console.log(`🎯 Step 1: Submitting with tool: ${submitTool.name}`);
+      const submitResult = await client.callTool({
+        name: submitTool.name,
+        arguments: {
+          prompt: parameters.prompt,
+          width: parameters.width || 512,
+          height: parameters.height || 512,
+          num_inference_steps: parameters.num_inference_steps || 4,
+          guidance_scale: parameters.guidance_scale || 1.0
+        }
+      });
+      
+      console.log('📤 Submit result:', submitResult);
+      
+      // 汎用的なレスポンス処理：どんなMCPサービスでも対応
+      const processResponse = (responseData) => {
+        let requestId = null;
+        let directImageData = null;
+
+        if (!responseData.content || !Array.isArray(responseData.content)) {
+          return { requestId, directImageData };
+        }
+
+        for (const content of responseData.content) {
+          // 直接メディアデータをチェック（画像・動画両対応）
+          if ((content.type === 'image' || content.type === 'video') && content.data) {
+            console.log(`✅ Found direct ${content.type} data`);
+            directImageData = content.data; // 変数名は既存のまま（画像・動画両用）
+          }
+
+          // request_idをチェック
+          if (content.type === 'text') {
+            const text = content.text;
+
+            // JSON形式のrequest_id
+            try {
+              const jsonData = JSON.parse(text);
+              if (jsonData.request_id) {
+                requestId = jsonData.request_id;
+                console.log('🆔 Found request_id (JSON):', requestId);
+              }
+            } catch (e) {
+              // マークダウン形式のrequest_id
+              const match = text.match(/\*\*Request ID:\*\*\s+([a-f0-9-]+)/i);
+              if (match) {
+                requestId = match[1];
+                console.log('🆔 Found request_id (markdown):', requestId);
+              }
+            }
+          }
+        }
+
+        return { requestId, directImageData };
+      };
+
+      console.log('🔍 Processing MCP response...');
+      const { requestId, directImageData } = processResponse(submitResult);
+
+      // 直接メディアデータがある場合は即座に処理（画像・動画両対応）
+      if (directImageData) {
+        console.log('⚡ Processing direct media response...');
+        const fs = await import('fs');
+
+        // Base64データからメディアタイプを判定して適切に処理
+        const base64Data = directImageData.replace(/^data:(image|video)\/\w+;base64,/, '');
+        const buffer = Buffer.from(base64Data, 'base64');
+
+        await fs.promises.writeFile(localPath, buffer);
+        console.log(`💾 Saved direct media to: ${localPath}`);
+
+        return {
+          success: true,
+          imageUrl: webPath,
+          localPath: localPath,
+          metadata: {
+            prompt: parameters.prompt,
+            service: serviceName,
+            timestamp: timestamp,
+            model: 'Direct Response',
+            type: 'immediate'
+          }
+        };
+      }
+
+      // request_idがある場合は非同期処理を継続
+      if (!requestId) {
+        throw new Error('No request_id or direct image data received from MCP service');
+      }
+      
+      console.log(`🆔 Got request_id: ${requestId}`);
+      
+      // Step 2: Status - 完了まで待機
+      const statusTool = toolsResponse.tools?.find(tool => tool.name.includes('status'));
+      if (!statusTool) {
+        throw new Error('No status tool found');
+      }
+      
+      console.log(`🔄 Step 2: Checking status with tool: ${statusTool.name}`);
+      let isCompleted = false;
+      let maxRetries = 30; // 最大30回チェック
+      let currentStatus = 'IN_QUEUE';
+      let queuePosition = null;
+
+      while (!isCompleted && maxRetries > 0) {
+        const statusResult = await client.callTool({
+          name: statusTool.name,
+          arguments: {
+            request_id: requestId
+          }
+        });
+
+        const currentCheck = 31 - maxRetries;
+        console.log(`⏳ Status check (${currentCheck}/30):`, statusResult);
+
+        // ステータスをチェック（マークダウンテキストから）
+        if (statusResult.content && Array.isArray(statusResult.content)) {
+          for (const content of statusResult.content) {
+            if (content.type === 'text') {
+              const text = content.text;
+
+              // キューポジション取得
+              const queueMatch = text.match(/queue_position['":\s]*(\d+)/i);
+              if (queueMatch) {
+                queuePosition = parseInt(queueMatch[1]);
+              }
+
+              // ステータス取得
+              if (text.includes('IN_PROGRESS')) {
+                currentStatus = 'IN_PROGRESS';
+              } else if (text.includes('COMPLETED') || text.includes('Status:** COMPLETED')) {
+                currentStatus = 'COMPLETED';
+                isCompleted = true;
+                break;
+              } else if (text.includes('FAILED') || text.includes('Status:** FAILED')) {
+                throw new Error('Generation failed');
+              }
+            }
+          }
+        }
+
+        // 進捗計算と送信
+        if (taskId) {
+          const progress = this.calculateProgress(currentCheck, 30, queuePosition, currentStatus);
+          let message = '';
+
+          if (queuePosition > 0) {
+            message = `キュー位置: ${queuePosition}`;
+          } else if (currentStatus === 'IN_PROGRESS') {
+            message = '生成中...';
+          } else {
+            message = '待機中...';
+          }
+
+          this.sendProgress(taskId, progress, message);
+        }
+
+        if (!isCompleted) {
+          await new Promise(resolve => setTimeout(resolve, 2000)); // 2秒待機
+          maxRetries--;
+        }
+      }
+      
+      if (!isCompleted) {
+        throw new Error('Generation timeout - did not complete within 180 seconds');
+      }
+      
+      // Step 3: Result - 結果を取得
+      const resultTool = toolsResponse.tools?.find(tool => tool.name.includes('result'));
+      if (!resultTool) {
+        throw new Error('No result tool found');
+      }
+      
+      console.log(`📥 Step 3: Getting result with tool: ${resultTool.name}`);
+      const resultResult = await client.callTool({
+        name: resultTool.name,
+        arguments: {
+          request_id: requestId
+        }
+      });
+      
+      console.log('✅ Final result:', resultResult);
+      
+      // 結果処理
+      if (resultResult.content && Array.isArray(resultResult.content)) {
+        for (const content of resultResult.content) {
+          if (content.type === 'image' && content.data) {
+            // Base64画像データを高品質で保存
+            const base64Data = content.data.replace(/^data:image\/[a-z]+;base64,/, '');
+            
+            // ディレクトリが存在しない場合は作成
+            const dir = path.dirname(localPath);
+            if (!fs.existsSync(dir)) {
+              fs.mkdirSync(dir, { recursive: true });
+            }
+            
+            // 高品質でBase64から直接保存（品質劣化防止）
+            const imageBuffer = Buffer.from(base64Data, 'base64');
+            fs.writeFileSync(localPath, imageBuffer);
+            console.log(`💾 High-quality image saved to: ${localPath} (${imageBuffer.length} bytes)`);
+            break;
+          } else if (content.type === 'text') {
+            const text = content.text;
+            
+            // Seedream V4形式のJSON構造をチェック
+            try {
+              const jsonData = JSON.parse(text);
+              if (jsonData.images && Array.isArray(jsonData.images) && jsonData.images.length > 0) {
+                const imageUrl = jsonData.images[0].url;
+                console.log(`🎯 Found Seedream V4 image URL: ${imageUrl}`);
+                await this.downloadAndSaveImage(imageUrl, localPath);
+                break;
+              }
+            } catch (e) {
+              // JSONでない場合は、テキストの中に画像URLが含まれている可能性をチェック
+              const urlMatch = text.match(/https?:\/\/[^\s\)]+\.(jpg|jpeg|png|gif)/i);
+              if (urlMatch) {
+                const imageUrl = urlMatch[0];
+                console.log(`🎯 Found URL in text: ${imageUrl}`);
+                await this.downloadAndSaveImage(imageUrl, localPath);
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      // 接続を閉じる
+      await client.close();
+
+      // 完了シグナル送信
+      if (taskId) {
+        this.sendProgress(taskId, 100, '完了');
+        if (this.server) {
+          this.server.sendProgress(taskId, {
+            type: 'completed',
+            percent: 100,
+            message: '生成完了'
+          });
+        }
+      }
+
+      return {
+        url: webPath,
+        localPath: localPath,
+        metadata: {
+          service: serviceName,
+          prompt: parameters.prompt,
+          timestamp: timestamp,
+          requestId: requestId,
+          mcpResponse: resultResult
+        }
+      };
+      
+    } catch (error) {
+      console.error(`❌ MCP service failed: ${serviceName}`, error);
+      throw error;
+    }
+  }
+  
+  /**
+   * 画像をダウンロードして保存
+   */
+  async downloadAndSaveImage(imageUrl, localPath) {
+    try {
+      console.log(`🔗 Downloading image from: ${imageUrl}`);
+      
+      // FAL CDN用の適切なヘッダーを設定
+      const headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+        'Accept': 'image/webp,image/apng,image/*,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.9',
+        'Cache-Control': 'no-cache'
+      };
+      
+      const response = await fetch(imageUrl, { headers });
+      console.log(`📡 Response status: ${response.status} ${response.statusText}`);
+      
+      if (!response.ok) {
+        // 詳細なエラー情報を取得
+        const errorText = await response.text().catch(() => 'No error text available');
+        console.error(`❌ Download failed with status ${response.status}: ${errorText}`);
+        throw new Error(`Failed to download image: ${response.status} - ${errorText}`);
+      }
+      
+      const buffer = await response.arrayBuffer();
+      console.log(`📦 Downloaded ${buffer.byteLength} bytes`);
+      
+      const fs = await import('fs');
+      
+      // ディレクトリが存在しない場合は作成
+      const dir = path.dirname(localPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      
+      fs.writeFileSync(localPath, Buffer.from(buffer));
+      console.log(`💾 Image saved to: ${localPath}`);
+      
+    } catch (error) {
+      console.error('❌ Failed to download/save image:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * プレースホルダー画像生成（開発用）
+   */
+  generatePlaceholderImage(prompt) {
+    const hash = this.hashString(prompt);
+    const hue = hash % 360;
+    
+    const svg = `
+      <svg width="512" height="512" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:hsl(${hue},70%,60%);stop-opacity:1" />
+            <stop offset="100%" style="stop-color:hsl(${(hue + 60) % 360},70%,40%);stop-opacity:1" />
+          </linearGradient>
+        </defs>
+        <rect width="512" height="512" fill="url(#grad)"/>
+        <text x="256" y="230" font-family="Arial" font-size="24" fill="white" text-anchor="middle">🎨</text>
+        <text x="256" y="270" font-family="Arial" font-size="16" fill="white" text-anchor="middle">${prompt.slice(0, 20)}</text>
+        <text x="256" y="300" font-family="Arial" font-size="14" fill="rgba(255,255,255,0.7)" text-anchor="middle">Placeholder Image</text>
+      </svg>
+    `;
+    
+    return `data:image/svg+xml;base64,${Buffer.from(svg, 'utf-8').toString('base64')}`;
+  }
+
+  /**
+   * 文字列のハッシュ値を計算
+   */
+  hashString(str) {
+    let hash = 0;
+    for (let i = 0; i < str.length; i++) {
+      const char = str.charCodeAt(i);
+      hash = ((hash << 5) - hash) + char;
+      hash = hash & hash;
+    }
+    return Math.abs(hash);
+  }
+
+  /**
+   * 利用可能な画像生成サービス一覧
+   */
+  getAvailableServices() {
+    return getAvailableModelIds();
+  }
+}

--- a/packages/daemon/src/security.js
+++ b/packages/daemon/src/security.js
@@ -1,0 +1,281 @@
+/**
+ * Security middleware for ChocoDrop Daemon
+ */
+
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { join } from 'path';
+import { homedir } from 'os';
+import crypto from 'crypto';
+
+const CONFIG_DIR = join(homedir(), '.config', 'chocodrop');
+const ALLOWLIST_PATH = join(CONFIG_DIR, 'allowlist.json');
+const CONFIG_PATH = join(CONFIG_DIR, 'config.json');
+
+// Rate limiting storage
+const rateLimitStore = new Map();
+
+/**
+ * Ensure config directory exists
+ */
+export async function ensureConfigDir() {
+  try {
+    await mkdir(CONFIG_DIR, { recursive: true });
+  } catch (error) {
+    if (error.code !== 'EEXIST') {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Load allowlist from disk
+ * @returns {Promise<string[]>} Array of allowed origins
+ */
+export async function loadAllowlist() {
+  try {
+    const content = await readFile(ALLOWLIST_PATH, 'utf-8');
+    const data = JSON.parse(content);
+    return data.origins || [];
+  } catch (error) {
+    // File doesn't exist or is invalid - return default
+    return ['http://localhost:3000', 'http://127.0.0.1:3000'];
+  }
+}
+
+/**
+ * Save allowlist to disk
+ * @param {string[]} origins - Array of allowed origins
+ */
+export async function saveAllowlist(origins) {
+  await ensureConfigDir();
+  await writeFile(ALLOWLIST_PATH, JSON.stringify({ origins }, null, 2));
+}
+
+/**
+ * Add origin to allowlist
+ * @param {string} origin - Origin to add
+ */
+export async function addToAllowlist(origin) {
+  const allowlist = await loadAllowlist();
+  if (!allowlist.includes(origin)) {
+    allowlist.push(origin);
+    await saveAllowlist(allowlist);
+  }
+}
+
+/**
+ * Load config from disk
+ * @returns {Promise<Object>} Configuration object
+ */
+export async function loadConfig() {
+  try {
+    const content = await readFile(CONFIG_PATH, 'utf-8');
+    return JSON.parse(content);
+  } catch (error) {
+    // Return default config
+    return {
+      security: {
+        rateLimit: {
+          windowMs: 60000, // 1 minute
+          maxRequests: 100, // 100 requests per minute
+        },
+        csrfEnabled: true,
+        safeMode: true, // No external requests by default
+      },
+    };
+  }
+}
+
+/**
+ * Rate limiting middleware
+ * @param {Object} options - Rate limit options
+ * @returns {Function} Express middleware
+ */
+export function rateLimit(options = {}) {
+  const windowMs = options.windowMs || 60000; // 1 minute
+  const maxRequests = options.maxRequests || 100;
+
+  return (req, res, next) => {
+    const key = req.ip || req.connection.remoteAddress;
+    const now = Date.now();
+
+    // Get or create rate limit data for this IP
+    let ipData = rateLimitStore.get(key);
+    if (!ipData) {
+      ipData = { count: 0, resetTime: now + windowMs };
+      rateLimitStore.set(key, ipData);
+    }
+
+    // Reset if window has passed
+    if (now > ipData.resetTime) {
+      ipData.count = 0;
+      ipData.resetTime = now + windowMs;
+    }
+
+    // Increment and check
+    ipData.count++;
+
+    if (ipData.count > maxRequests) {
+      return res.status(429).json({
+        error: 'Too many requests',
+        message: `Rate limit exceeded. Try again in ${Math.ceil((ipData.resetTime - now) / 1000)}s`,
+        retryAfter: Math.ceil((ipData.resetTime - now) / 1000),
+      });
+    }
+
+    // Add rate limit headers
+    res.setHeader('X-RateLimit-Limit', maxRequests);
+    res.setHeader('X-RateLimit-Remaining', maxRequests - ipData.count);
+    res.setHeader('X-RateLimit-Reset', new Date(ipData.resetTime).toISOString());
+
+    next();
+  };
+}
+
+/**
+ * CSRF token generation and validation
+ */
+export class CSRFProtection {
+  constructor() {
+    this.tokens = new Map();
+    this.cleanupInterval = setInterval(() => this.cleanup(), 600000); // 10 minutes
+  }
+
+  /**
+   * Generate a new CSRF token
+   * @returns {string} CSRF token
+   */
+  generateToken() {
+    const token = crypto.randomBytes(32).toString('hex');
+    this.tokens.set(token, Date.now());
+    return token;
+  }
+
+  /**
+   * Validate CSRF token
+   * @param {string} token - Token to validate
+   * @returns {boolean} True if valid
+   */
+  validateToken(token) {
+    if (!token) return false;
+    const timestamp = this.tokens.get(token);
+    if (!timestamp) return false;
+
+    // Token expires after 1 hour
+    const isExpired = Date.now() - timestamp > 3600000;
+    if (isExpired) {
+      this.tokens.delete(token);
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Clean up expired tokens
+   */
+  cleanup() {
+    const now = Date.now();
+    for (const [token, timestamp] of this.tokens.entries()) {
+      if (now - timestamp > 3600000) {
+        this.tokens.delete(token);
+      }
+    }
+  }
+
+  /**
+   * Express middleware for CSRF protection
+   */
+  middleware() {
+    return (req, res, next) => {
+      // Skip CSRF for GET requests
+      if (req.method === 'GET') {
+        return next();
+      }
+
+      const token = req.headers['x-csrf-token'] || req.body?.csrfToken;
+      if (!this.validateToken(token)) {
+        return res.status(403).json({
+          error: 'Invalid CSRF token',
+          message: 'CSRF token is missing or invalid',
+        });
+      }
+
+      next();
+    };
+  }
+
+  /**
+   * Destroy cleanup interval
+   */
+  destroy() {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+    }
+  }
+}
+
+/**
+ * CORS middleware with allowlist support
+ * @returns {Function} Express middleware
+ */
+export async function corsWithAllowlist() {
+  const allowlist = await loadAllowlist();
+
+  return (req, res, next) => {
+    const origin = req.headers.origin;
+
+    // No origin = same-origin request (allow)
+    if (!origin) {
+      return next();
+    }
+
+    // Check if origin is in allowlist
+    const isAllowed = allowlist.some(allowed => {
+      // Exact match
+      if (origin === allowed) return true;
+      // Wildcard localhost (any port)
+      if (allowed === 'http://localhost:*' && origin.startsWith('http://localhost:')) return true;
+      if (allowed === 'http://127.0.0.1:*' && origin.startsWith('http://127.0.0.1:')) return true;
+      return false;
+    });
+
+    if (isAllowed) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+      res.setHeader('Access-Control-Allow-Methods', 'GET, POST');
+      res.setHeader('Access-Control-Allow-Headers', 'Content-Type, X-CSRF-Token');
+
+      // Handle preflight
+      if (req.method === 'OPTIONS') {
+        return res.sendStatus(200);
+      }
+
+      return next();
+    }
+
+    // Origin not allowed
+    res.status(403).json({
+      error: 'Origin not allowed',
+      message: 'This origin is not in the allowlist. Add it via the settings page.',
+      origin,
+    });
+  };
+}
+
+/**
+ * Log security events (with PII masking)
+ * @param {string} event - Event type
+ * @param {Object} data - Event data
+ */
+export function logSecurityEvent(event, data) {
+  const sanitized = {
+    ...data,
+    // Mask IP addresses
+    ip: data.ip ? data.ip.replace(/\d+\.\d+\.\d+\.\d+/, 'xxx.xxx.xxx.xxx') : undefined,
+    // Mask user agents
+    userAgent: data.userAgent ? 'MASKED' : undefined,
+  };
+
+  console.log(`[SECURITY] ${event}:`, sanitized);
+}

--- a/packages/meta/package.json
+++ b/packages/meta/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "chocodrop",
+  "version": "2.0.0",
+  "description": "ChocoDrop - compatibility layer (deprecated, use @chocodrop/sdk instead)",
+  "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "keywords": [
+    "chocodrop",
+    "threejs",
+    "compatibility"
+  ],
+  "author": {
+    "name": "ChocoDrop Project",
+    "email": "chocodrop.dev@gmail.com"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "@chocodrop/sdk": "^1.0.0"
+  },
+  "peerDependencies": {
+    "three": ">=0.170.0 <=0.180.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "deprecated": "Please use @chocodrop/sdk directly. This package will be removed in v3.0.0"
+}

--- a/packages/meta/src/index.js
+++ b/packages/meta/src/index.js
@@ -1,0 +1,99 @@
+/**
+ * ChocoDrop Compatibility Layer
+ *
+ * This package provides backward compatibility for the old createChocoDrop API.
+ * It is deprecated and will be removed in v3.0.0.
+ *
+ * Please migrate to @chocodrop/sdk:
+ *   import { ready, attach } from '@chocodrop/sdk';
+ *   await ready();
+ *   await attach(scene, { camera, renderer });
+ */
+
+// Track if deprecation warning has been shown
+let deprecationWarningShown = false;
+
+/**
+ * Show deprecation warning (once per session)
+ */
+function showDeprecationWarning() {
+  if (deprecationWarningShown) return;
+  deprecationWarningShown = true;
+
+  console.warn(
+    '%c⚠️ ChocoDrop Deprecation Warning',
+    'color: #ff6ad5; font-weight: bold; font-size: 14px;',
+    '\n\nThe `createChocoDrop` function is deprecated and will be removed in v3.0.0.\n\n' +
+    'Please migrate to the new API:\n\n' +
+    'OLD:\n' +
+    '  import { createChocoDrop } from \'chocodrop\';\n' +
+    '  createChocoDrop(scene, { camera, renderer });\n\n' +
+    'NEW:\n' +
+    '  <script src="http://127.0.0.1:43110/sdk.js"></script>\n' +
+    '  <script type="module">\n' +
+    '    await window.chocodrop.ready();\n' +
+    '    await window.chocodrop.attach(scene, { camera, renderer });\n' +
+    '  </script>\n\n' +
+    'For more information, see: https://github.com/nyukicorn/chocodrop\n'
+  );
+}
+
+/**
+ * Create ChocoDrop instance (DEPRECATED)
+ *
+ * @deprecated Please use @chocodrop/sdk directly
+ * @param {THREE.Scene} scene - Three.js scene
+ * @param {Object} options - Configuration options
+ * @returns {Promise<Object>} ChocoDrop instance
+ */
+export async function createChocoDrop(scene, options = {}) {
+  showDeprecationWarning();
+
+  // Try to load SDK from daemon
+  try {
+    // Dynamic import of SDK from daemon
+    const SDK_URL = 'http://127.0.0.1:43110/sdk.js';
+
+    // Load SDK script
+    if (!window.chocodrop) {
+      await new Promise((resolve, reject) => {
+        const script = document.createElement('script');
+        script.src = SDK_URL;
+        script.onload = resolve;
+        script.onerror = () => reject(new Error('Failed to load ChocoDrop SDK from daemon'));
+        document.head.appendChild(script);
+      });
+    }
+
+    // Wait a bit for SDK to initialize
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    if (!window.chocodrop) {
+      throw new Error('ChocoDrop SDK not available');
+    }
+
+    // Check if daemon is running
+    await window.chocodrop.ready();
+
+    // Attach to scene
+    return await window.chocodrop.attach(scene, options);
+  } catch (error) {
+    console.error('Failed to initialize ChocoDrop:', error);
+
+    // Fallback: Return minimal compatibility object
+    console.warn('Using compatibility fallback - limited functionality');
+
+    return {
+      client: null,
+      sceneManager: null,
+      ui: null,
+      error: error.message,
+      reload: async () => {
+        console.warn('Reload not available in compatibility mode');
+      }
+    };
+  }
+}
+
+// Default export
+export default createChocoDrop;

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@chocodrop/sdk",
+  "version": "1.0.0",
+  "description": "ChocoDrop browser SDK - client library for Three.js scene integration",
+  "type": "module",
+  "main": "./dist/chocodrop-sdk.esm.js",
+  "module": "./dist/chocodrop-sdk.esm.js",
+  "browser": "./dist/chocodrop-sdk.umd.js",
+  "exports": {
+    ".": {
+      "import": "./dist/chocodrop-sdk.esm.js",
+      "require": "./dist/chocodrop-sdk.umd.js"
+    }
+  },
+  "types": "./src/index.d.ts",
+  "keywords": [
+    "chocodrop",
+    "sdk",
+    "threejs",
+    "browser",
+    "3d"
+  ],
+  "author": {
+    "name": "ChocoDrop Project",
+    "email": "chocodrop.dev@gmail.com"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "three": ">=0.170.0 <=0.180.0"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  }
+}

--- a/packages/sdk/src/index.js
+++ b/packages/sdk/src/index.js
@@ -1,0 +1,196 @@
+/**
+ * ChocoDrop Browser SDK - Minimal version with existing UI integration
+ */
+
+(() => {
+  const BASE = 'http://127.0.0.1:43110';
+  const ORIGIN = typeof location !== 'undefined' ? location.origin : '';
+
+  /**
+   * Timeout helper
+   */
+  function timeout(ms) {
+    return new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), ms)
+    );
+  }
+
+  /**
+   * Ping daemon health
+   */
+  async function ping() {
+    try {
+      const response = await Promise.race([
+        fetch(`${BASE}/v1/health`),
+        timeout(1000)
+      ]);
+      return response && response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Get or create root overlay element
+   */
+  function getRootOverlay() {
+    let el = document.getElementById('__chocodrop_overlay__');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = '__chocodrop_overlay__';
+      Object.assign(el.style, {
+        position: 'fixed',
+        right: '16px',
+        bottom: '16px',
+        zIndex: '999999'
+      });
+      document.body.appendChild(el);
+    }
+    return el;
+  }
+
+  /**
+   * Check if daemon is running
+   */
+  async function ready() {
+    const isRunning = await ping();
+    if (isRunning) {
+      console.log('✅ ChocoDrop daemon is ready');
+      return true;
+    }
+
+    // Daemon not running - show instructions
+    const shouldStart = confirm(
+      'ChocoDrop daemon is not running.\n\n' +
+      'Please run in terminal:\n' +
+      '  npx chocodropd\n\n' +
+      'Then reload this page.\n\n' +
+      'Continue?'
+    );
+
+    if (!shouldStart) {
+      throw new Error('ChocoDrop daemon not running');
+    }
+
+    alert(
+      'Start ChocoDrop daemon in terminal:\n\n' +
+      '  npx chocodropd\n\n' +
+      'Then reload this page.'
+    );
+
+    throw new Error('Prompted user to start daemon');
+  }
+
+  /**
+   * Attach ChocoDrop to scene
+   */
+  async function attach(scene, opts = {}) {
+    const root = getRootOverlay();
+    let mounted = false;
+
+    // Try to load existing CommandUI from daemon
+    try {
+      // First, try to load CommandUI dependencies
+      const [CommandUIMod, SceneManagerMod, ClientMod] = await Promise.all([
+        import(`${BASE}/ui/CommandUI.js`),
+        import(`${BASE}/ui/SceneManager.js`),
+        import(`${BASE}/ui/LiveCommandClient.js`)
+      ]);
+
+      const CommandUI = CommandUIMod.CommandUI || CommandUIMod.default;
+      const SceneManager = SceneManagerMod.SceneManager || SceneManagerMod.default;
+      const LiveCommandClient = ClientMod.LiveCommandClient || ClientMod.default;
+
+      if (CommandUI && SceneManager && LiveCommandClient) {
+        // Initialize existing UI
+        const sceneManager = new SceneManager(scene, opts);
+        const client = new LiveCommandClient({ serverUrl: BASE });
+        const ui = new CommandUI({
+          sceneManager,
+          client,
+          onControlsToggle: opts.onControlsToggle,
+          ...opts.uiOptions
+        });
+
+        ui.show();
+        mounted = true;
+
+        console.log('✅ ChocoDrop UI loaded from existing implementation');
+
+        return {
+          ui,
+          sceneManager,
+          client,
+          reload: () => fetch(`${BASE}/v1/reload`, {
+            method: 'POST',
+            headers: { 'x-chocodrop-origin': ORIGIN }
+          })
+        };
+      }
+    } catch (error) {
+      console.warn('Could not load existing UI, using fallback:', error);
+    }
+
+    // Fallback: Simple placeholder UI
+    if (!mounted) {
+      root.innerHTML = '';
+      const wrapper = document.createElement('div');
+      Object.assign(wrapper.style, {
+        background: 'rgba(20, 20, 20, 0.95)',
+        color: '#fff',
+        padding: '12px 16px',
+        borderRadius: '12px',
+        boxShadow: '0 6px 18px rgba(0, 0, 0, 0.3)',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        fontSize: '14px'
+      });
+
+      wrapper.innerHTML = `
+        <div style="margin-bottom: 8px; font-weight: 600;">🍫 ChocoDrop</div>
+        <button id="__cd_reload__" style="
+          background: rgba(255, 255, 255, 0.1);
+          border: 1px solid rgba(255, 255, 255, 0.2);
+          color: white;
+          padding: 6px 12px;
+          border-radius: 6px;
+          cursor: pointer;
+          font-size: 13px;
+        ">🔄 Reload Config</button>
+      `;
+
+      root.appendChild(wrapper);
+
+      const reloadBtn = wrapper.querySelector('#__cd_reload__');
+      reloadBtn.onclick = async () => {
+        try {
+          await fetch(`${BASE}/v1/reload`, {
+            method: 'POST',
+            headers: { 'x-chocodrop-origin': ORIGIN }
+          });
+          alert('Configuration reloaded!');
+        } catch (error) {
+          alert('Failed to reload: ' + error.message);
+        }
+      };
+
+      console.log('✅ ChocoDrop placeholder UI loaded');
+    }
+
+    return {
+      reload: () => fetch(`${BASE}/v1/reload`, {
+        method: 'POST',
+        headers: { 'x-chocodrop-origin': ORIGIN }
+      })
+    };
+  }
+
+  // Export to window
+  if (typeof window !== 'undefined') {
+    window.chocodrop = { ready, attach };
+  }
+
+  // Export for ES modules
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { ready, attach };
+  }
+})();


### PR DESCRIPTION
## 概要
- 常駐型アーキテクチャを導入:
  - `chocodropd` (127.0.0.1:43110)
  - `/sdk.js` 配信 + `window.chocodrop.{ready, attach, reload}`
- 既存UIを `/ui/*` から配信し、attach で右下パネルを表示
- MCPブリッジ: `/v1/generate` → ローカル kamuicode のみ

## 目的
- 「各プロジェクトでサーバー起動」の手間を撤廃し、1行(またはブックマークレット)で"ぽん"体験を実現
- 安全性をローカル限定・許可制で担保

## 変更点
- daemon: `GET /v1/health`, `GET /sdk.js`, `POST /v1/reload`, `POST /v1/generate`
- SDK: `ready/attach/reload` 追加
- セキュリティ層: CORS(許可リスト), CSRF, レート制限, 同時実行上限, タイムアウト
- 互換: `createChocoDrop` を非推奨ラッパで維持
- サンプル: `bookmarklet.html`
- README: 新アーキテクチャ/導入手順/安全の約束を追記

## セキュリティ/設計の要点
- 127.0.0.1 固定（外部公開なし）
- 接続先はローカル kamuicode のみ（外部URL不可）
- 初回オリジン許可（ホワイトリスト）+ 厳格CORS + CSRF
- 外部送信は明示時のみ（UIで送信先表示）
- no telemetry / ログPIIマスク / 画像EXIF除去

## 互換/移行
- 旧: \`import { createChocoDrop } from 'chocodrop'\`
- 新: \`<script src="http://127.0.0.1:43110/sdk.js">\` or \`import { ready, attach } from '@chocodrop/sdk'\`
- v3で旧API削除予定（本PRでは非推奨警告のみ）

## テスト計画（抜粋）
- \`curl http://127.0.0.1:43110/v1/health\` が 200
- SDK読込 → \`ready()\` 未起動時の案内 → 起動後 \`attach()\` で右下UI表示
- CORS/許可リスト: 未許可オリジンで 403 / 許可後 200
- \`/v1/generate\` がローカル kamuicode にのみ到達（外部接続なしを確認）
- レート制限/同時実行/タイムアウトが効く

## スクショ/動画
- [ ] health OK
- [ ] 右下UI表示
- [ ] 許可ダイアログ

## チェックリスト
- [ ] 127.0.0.1 以外で listen していない
- [ ] 外部URLへの接続コードが存在しない（kamuicode以外）
- [ ] postinstall 等の実行スクリプトなし
- [ ] lockfile あり、\`npm ci\` で再現可能
- [ ] UNINSTALL.md / SECURITY.md / README 更新済み

---

### レビュワー用チェックリスト

#### Security
- [ ] daemon が 127.0.0.1 以外にバインドされない
- [ ] egress（外部送信）ルール: kamuicode ローカル以外に到達しない
- [ ] 許可オリジン + CORS + CSRF が既定ON
- [ ] レート制限／同時実行上限／タイムアウトの閾値が妥当

#### SDK/UX
- [ ] \`ready()\` 未起動時のガイドが明確
- [ ] \`attach()\` で右下UIが安定表示（CSPの影響があればフォールバック動作）
- [ ] \`/v1/reload\` が UI から動作

#### 配布/品質
- [ ] postinstall 等なし、\`npm ci\` でOK
- [ ] 依存が最小限＆ピン止め
- [ ] README のクイックスタートが事実と一致
- [ ] UNINSTALL.md/SECURITY.md が最新

Fixes: (任意)
BREAKING CHANGE: なし（旧APIは暫定存続）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a local daemon with security, health checks, and content generation endpoints.
  - Added a lightweight browser SDK enabling ready/attach flows for Three.js scenes.
  - Provided a bookmarklet workflow for quick in-page integration.
  - Delivered a compatibility layer for the legacy API, with deprecation warnings.

- Documentation
  - Updated README with v2 architecture, new setup steps, and deprecation notice for v1.x.
  - Added a detailed bookmarklet usage page.

- Chores
  - Configured workspaces to support a monorepo structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->